### PR TITLE
feat: expand pentesting checks

### DIFF
--- a/extensions/business/cybersec/pentesting/service_info_mixin.py
+++ b/extensions/business/cybersec/pentesting/service_info_mixin.py
@@ -1,6 +1,8 @@
 import socket
 import ftplib
 import requests
+import ssl
+from datetime import datetime
 
 class _ServiceInfoMixin:
   """
@@ -52,7 +54,32 @@ class _ServiceInfoMixin:
         resp = requests.get(url, timeout=3, verify=False)
         info = (f"HTTPS {resp.status_code} {resp.reason}; Server: {resp.headers.get('Server')}")
     except Exception as e:
-      info = f"Banner grab failed on port {port}: {e}"      
+      info = f"Banner grab failed on port {port}: {e}"
+    return info
+
+
+  def _service_info_tls(self, target, port):
+    info = None
+    try:
+      if port in (443, 8443):
+        context = ssl.create_default_context()
+        with socket.create_connection((target, port), timeout=3) as sock:
+          with context.wrap_socket(sock, server_hostname=target) as ssock:
+            cert = ssock.getpeercert()
+            proto = ssock.version()
+            cipher = ssock.cipher()
+            expires = cert.get("notAfter")
+            if expires:
+              try:
+                exp = datetime.strptime(expires, "%b %d %H:%M:%S %Y %Z")
+                days = (exp - datetime.utcnow()).days
+                info = f"TLS {proto} {cipher[0]}; cert exp in {days} days"
+              except Exception:
+                info = f"TLS {proto} {cipher[0]}; cert expires {expires}"
+            else:
+              info = f"TLS {proto} {cipher[0]}"
+    except Exception as e:
+      info = f"TLS info fetch failed on port {port}: {e}"
     return info
 
 

--- a/extensions/business/cybersec/pentesting/web_tests_mixin.py
+++ b/extensions/business/cybersec/pentesting/web_tests_mixin.py
@@ -1,5 +1,6 @@
 
 import requests
+from urllib.parse import quote
 
 class _WebTestsMixin:
   """
@@ -32,12 +33,47 @@ class _WebTestsMixin:
       for marker in ["API_KEY", "PASSWORD", "SECRET", "BEGIN RSA PRIVATE KEY"]:
         if marker in text:
           self.logger(f"[{target}] Sensitive '{marker}' found on {base_url}.")
+      # Check for missing security headers
+      security_headers = [
+        "Content-Security-Policy",
+        "X-Frame-Options",
+        "X-Content-Type-Options",
+        "Strict-Transport-Security",
+        "Referrer-Policy",
+      ]
+      for header in security_headers:
+        if header not in resp_main.headers:
+          self.logger(f"[{target}] Missing security header {header} on {base_url}.")
+      # Check cookies for Secure/HttpOnly flags
+      cookies_hdr = resp_main.headers.get("Set-Cookie", "")
+      if cookies_hdr:
+        for cookie in cookies_hdr.split(","):
+          if "Secure" not in cookie:
+            self.logger(f"[{target}] Cookie missing Secure flag: {cookie.strip()} on {base_url}.")
+          if "HttpOnly" not in cookie:
+            self.logger(f"[{target}] Cookie missing HttpOnly flag: {cookie.strip()} on {base_url}.")
+      # Detect directory listing
+      if "Index of /" in resp_main.text:
+        self.logger(f"[{target}] Directory listing exposed at {base_url}.")
       # Basic XSS reflection test
       payload = "<script>alert(1)</script>"
       test_url = base_url.rstrip("/") + f"/{payload}"
       resp_test = requests.get(test_url, timeout=3, verify=False)
       if payload in resp_test.text:
         self.logger(f"[{target}] VULNERABLE: Reflected XSS at {test_url}.")
+      # Path traversal test
+      trav_url = base_url.rstrip("/") + "/../../../../etc/passwd"
+      resp_trav = requests.get(trav_url, timeout=2, verify=False)
+      if "root:x:" in resp_trav.text:
+        self.logger(f"[{target}] VULNERABLE: Path traversal at {trav_url}.")
+      # Simple SQL injection probe
+      inj_payload = quote("1' OR '1'='1")
+      inj_url = base_url + f"?id={inj_payload}"
+      resp_inj = requests.get(inj_url, timeout=3, verify=False)
+      errors = ["sql", "syntax", "mysql", "psql", "postgres", "sqlite", "ora-"]
+      body = resp_inj.text.lower()
+      if any(err in body for err in errors):
+        self.logger(f"[{target}] Potential SQL injection response at {inj_url}.")
     except Exception as e:
       self.logger(f"[{target}] Web test error on port {port}: {e}")
     return


### PR DESCRIPTION
## Summary
- check security headers, cookie flags, path traversal and SQLi during web tests
- report TLS protocol/certificate details for HTTPS services

## Testing
- `python -m py_compile extensions/business/cybersec/pentesting/web_tests_mixin.py extensions/business/cybersec/pentesting/service_info_mixin.py`


------
https://chatgpt.com/codex/tasks/task_e_68a0f0187e44832c86b84ce0ddef438c