### PR TITLE
feat: add cstore hsync endpoint

### DIFF
--- a/extensions/business/cstore/cstore_manager_api.py
+++ b/extensions/business/cstore/cstore_manager_api.py
@@ -2,7 +2,7 @@ from typing import Any
 
 from naeural_core.business.default.web_app.fast_api_web_app import FastApiWebAppPlugin as BasePlugin
 
-__VER__ = '0.2.2'
+__VER__ = '0.2.3'
 
 
 _CONFIG = {
@@ -194,3 +194,42 @@ class CstoreManagerApiPlugin(BasePlugin):
 
     return value
 
+
+  @BasePlugin.endpoint(method="post", require_token=False)
+  def hsync(self, hkey: str, chainstore_peers: list = None):
+    """
+    Refresh one hash namespace from live peer state.
+
+    Parameters
+    ----------
+    hkey : str
+      Logical hash namespace that should be merged from peer data.
+    chainstore_peers : list, optional
+      Additional peer addresses to target for this request. When omitted, the
+      wrapper leaves peer selection untouched so ``chainstore_hsync`` can use
+      its normal default-peer behavior.
+
+    Returns
+    -------
+    dict
+      Result envelope returned by ``chainstore_hsync``. On success it includes
+      the refreshed ``hkey``, the accepted ``source_peer``, and
+      ``merged_fields``.
+
+    Notes
+    -----
+    This wrapper is intentionally thin. The merge-only semantics, allowed-peer
+    filtering, and timeout behavior all live in `naeural_core`.
+    """
+    start_timer = self.time()
+    # Keep per-call peer targeting explicit so apps can trigger boot-time
+    # refreshes without mutating plugin-wide configuration.
+    result = self.chainstore_hsync(
+      hkey=hkey,
+      debug=self.cfg_debug,
+      extra_peers=chainstore_peers,
+    )
+    elapsed_time = self.time() - start_timer
+    self.Pd(f"CStore hsync took {elapsed_time:.4f} seconds")
+
+    return result

--- a/extensions/business/cstore/test_cstore_manager_api.py
+++ b/extensions/business/cstore/test_cstore_manager_api.py
@@ -1,0 +1,89 @@
+import unittest
+from pathlib import Path
+from types import SimpleNamespace
+
+
+ROOT = Path(__file__).resolve().parents[3]
+
+
+class _FakeBasePlugin:
+  CONFIG = {"VALIDATION_RULES": {}}
+
+  def __init__(self, **kwargs):
+    self.cfg_debug = kwargs.get("DEBUG", False)
+    self.bc = SimpleNamespace(address="0xADDR", eth_address="0xETH")
+    self._now = 0.0
+    self.messages = []
+
+  @staticmethod
+  def endpoint(method="get", require_token=False):  # pylint: disable=unused-argument
+    def decorator(func):
+      return func
+
+    return decorator
+
+  def on_init(self):
+    return None
+
+  def P(self, msg, *args, **kwargs):  # pylint: disable=unused-argument
+    self.messages.append(msg)
+
+  def time(self):
+    return self._now
+
+
+def _load_plugin_class():
+  source_path = ROOT / "extensions" / "business" / "cstore" / "cstore_manager_api.py"
+  source = source_path.read_text(encoding="utf-8")
+  source = source.replace(
+    "from naeural_core.business.default.web_app.fast_api_web_app import FastApiWebAppPlugin as BasePlugin\n",
+    "",
+  )
+  namespace = {"BasePlugin": _FakeBasePlugin, "__name__": "loaded_cstore_manager_api"}
+  exec(compile(source, str(source_path), "exec"), namespace)  # noqa: S102
+  return namespace["CstoreManagerApiPlugin"]
+
+
+CstoreManagerApiPlugin = _load_plugin_class()
+
+
+class CstoreManagerApiPluginTests(unittest.TestCase):
+  def _make_plugin(self):
+    plugin = CstoreManagerApiPlugin()
+    plugin.cfg_debug = False
+    plugin.calls = []
+
+    def _record_hsync(**kwargs):
+      plugin.calls.append(kwargs)
+      return {"hkey": kwargs["hkey"], "source_peer": "peer-1", "merged_fields": 2}
+
+    plugin.chainstore_hsync = _record_hsync
+    return plugin
+
+  def test_hsync_preserves_default_peer_selection_when_peers_are_omitted(self):
+    plugin = self._make_plugin()
+
+    result = plugin.hsync(hkey="players")
+
+    self.assertEqual(
+      result,
+      {"hkey": "players", "source_peer": "peer-1", "merged_fields": 2},
+    )
+    self.assertEqual(
+      plugin.calls,
+      [{"hkey": "players", "debug": False, "extra_peers": None}],
+    )
+
+  def test_hsync_forwards_explicit_chainstore_peers(self):
+    plugin = self._make_plugin()
+
+    plugin.hsync(hkey="players", chainstore_peers=["peer-a", "peer-b"])
+
+    self.assertEqual(
+      plugin.calls,
+      [{"hkey": "players", "debug": False, "extra_peers": ["peer-a", "peer-b"]}],
+    )
+
+
+if __name__ == "__main__":
+  unittest.main()


### PR DESCRIPTION
## Summary
- add a thin `POST /hsync` CStore wrapper that delegates to `chainstore_hsync(...)`
- preserve per-call peer targeting by forwarding `chainstore_peers` as `extra_peers`
- add focused wrapper tests for default-peer behavior and explicit peer forwarding

## Verification
- pass: `python -m compileall extensions/business/cstore/cstore_manager_api.py extensions/business/cstore/test_cstore_manager_api.py`
- pass: `python -m unittest discover -s extensions/business/cstore -p 'test_*.py'`

## Dependency
- pairs with `Ratio1/naeural_core` PR #197 for the runtime `hsync` implementation

## Notes
- this PR intentionally keeps the edge layer thin and does not add aliases or automatic startup sync logic