### PR TITLE
fix: reduce inference capacity cstore spam

### DIFF
--- a/extensions/business/edge_inference_api/base_inference_api.py
+++ b/extensions/business/edge_inference_api/base_inference_api.py
@@ -134,19 +134,22 @@ _CONFIG = {
   "ALLOW_ANONYMOUS_ACCESS": True,
 
   "METRICS_REFRESH_SECONDS": 5 * 60,  # 5 minutes
-  "REQUEST_BALANCING_ENABLED": False,
-  "REQUEST_BALANCING_GROUP": None,
-  "REQUEST_BALANCING_CAPACITY": 1,
-  "REQUEST_BALANCING_PENDING_LIMIT": None,
-  "REQUEST_BALANCING_ANNOUNCE_PERIOD": 60,
-  "REQUEST_BALANCING_PEER_STALE_SECONDS": 180,
-  "REQUEST_BALANCING_MAILBOX_POLL_PERIOD": 1,
-  "REQUEST_BALANCING_CAPACITY_CSTORE_TIMEOUT": 2,
-  "REQUEST_BALANCING_CAPACITY_CSTORE_MAX_RETRIES": 0,
-  "REQUEST_BALANCING_CAPACITY_WARN_PERIOD": 60,
-  "REQUEST_BALANCING_MAX_CSTORE_BYTES": 512 * 1024,
-  "REQUEST_BALANCING_REQUEST_TTL_SECONDS": None,
-  "REQUEST_BALANCING_RESULT_TTL_SECONDS": None,
+  "REQUEST_BALANCING_ENABLED": False,  # enable peer-to-peer request delegation through ChainStore mailboxes
+  "REQUEST_BALANCING_GROUP": None,  # logical pool name; only instances in the same group share capacity/work
+  "REQUEST_BALANCING_CAPACITY": 1,  # max concurrent delegated executions accepted by this instance
+  "REQUEST_BALANCING_PENDING_LIMIT": None,  # max queued local requests; defaults to a capacity-based limit
+  "REQUEST_BALANCING_ANNOUNCE_PERIOD": 60,  # retry interval after a capacity publish fails or has not succeeded yet
+  "REQUEST_BALANCING_CAPACITY_REFRESH_PERIOD": 300,  # slow keepalive for unchanged successful capacity records
+  "REQUEST_BALANCING_CAPACITY_REFRESH_JITTER_SECONDS": 120,  # stable per-instance offset that spreads refresh load
+  "REQUEST_BALANCING_CAPACITY_DEBOUNCE_SECONDS": 10,  # minimum delay between successful changed-capacity publishes
+  "REQUEST_BALANCING_PEER_STALE_SECONDS": 600,  # ignore peer capacity records older than this
+  "REQUEST_BALANCING_MAILBOX_POLL_PERIOD": 1,  # how often executors poll delegated request/result mailboxes
+  "REQUEST_BALANCING_CAPACITY_CSTORE_TIMEOUT": 2,  # per-attempt confirmation wait for advisory capacity writes
+  "REQUEST_BALANCING_CAPACITY_CSTORE_MAX_RETRIES": 0,  # retries inside one capacity write attempt; keep low for soft-state
+  "REQUEST_BALANCING_CAPACITY_WARN_PERIOD": 60,  # throttle warning logs for failed capacity publishes
+  "REQUEST_BALANCING_MAX_CSTORE_BYTES": 512 * 1024,  # reject delegated request/result envelopes above this size
+  "REQUEST_BALANCING_REQUEST_TTL_SECONDS": None,  # optional delegated request mailbox retention override
+  "REQUEST_BALANCING_RESULT_TTL_SECONDS": None,  # optional delegated result mailbox retention override
 
   # Semaphore key for paired plugin synchronization (e.g., with WAR containers)
   # When set, this plugin will signal readiness and expose env vars to paired plugins
@@ -226,6 +229,8 @@ class BaseInferenceApiPlugin(
     self.last_persistence_save = 0
     self._last_capacity_announce = 0.0
     self._last_capacity_warn = 0.0
+    self._last_capacity_publish_ok = False
+    self._last_capacity_publish_snapshot = None
     self._last_balancing_mailbox_poll = 0.0
     self.load_persistence_data()
     tunneling_str = f"(with tunneling enabled)" if self.cfg_tunnel_engine_enabled else ""
@@ -341,6 +346,80 @@ class BaseInferenceApiPlugin(
       return configured
     return max(8, 4 * self._get_balancing_capacity())
 
+  def _get_capacity_announce_period(self):
+    """Return the minimum retry interval after a failed capacity publish.
+
+    Returns
+    -------
+    float
+        Non-negative retry interval in seconds.
+    """
+    value = getattr(self, 'cfg_request_balancing_announce_period', 60)
+    if isinstance(value, bool) or not isinstance(value, (int, float)):
+      return 60.0
+    return max(0.0, float(value))
+
+  def _get_capacity_refresh_period(self):
+    """Return the periodic refresh interval for unchanged capacity records.
+
+    Returns
+    -------
+    float
+        Non-negative refresh interval in seconds. A value of 0 disables
+        unchanged periodic refreshes, leaving only change-triggered publishes.
+    """
+    value = getattr(self, 'cfg_request_balancing_capacity_refresh_period', 300)
+    if isinstance(value, bool) or not isinstance(value, (int, float)):
+      return 300.0
+    return max(0.0, float(value))
+
+  def _get_capacity_refresh_jitter_seconds(self):
+    """Return stable per-instance jitter applied to unchanged refreshes.
+
+    Returns
+    -------
+    float
+        Non-negative jitter window in seconds.
+    """
+    value = getattr(self, 'cfg_request_balancing_capacity_refresh_jitter_seconds', 120)
+    if isinstance(value, bool) or not isinstance(value, (int, float)):
+      return 120.0
+    return max(0.0, float(value))
+
+  def _get_capacity_refresh_due_seconds(self):
+    """Return this instance's unchanged-capacity refresh interval.
+
+    Returns
+    -------
+    float
+        Base refresh period plus a stable per-instance offset.
+    """
+    refresh_period = self._get_capacity_refresh_period()
+    jitter_seconds = self._get_capacity_refresh_jitter_seconds()
+    if refresh_period <= 0 or jitter_seconds < 1:
+      return refresh_period
+    # Use deterministic jitter instead of runtime randomness so the same
+    # instance keeps its offset across restarts without persisting extra state.
+    jitter_bucket_count = int(jitter_seconds) + 1
+    jitter_offset = int(
+      self.get_hash(self._get_instance_balance_key(), length=8, algorithm='sha256'),
+      16,
+    ) % jitter_bucket_count
+    return refresh_period + float(jitter_offset)
+
+  def _get_capacity_debounce_seconds(self):
+    """Return the minimum delay between successful changed-capacity publishes.
+
+    Returns
+    -------
+    float
+        Non-negative debounce interval in seconds.
+    """
+    value = getattr(self, 'cfg_request_balancing_capacity_debounce_seconds', 10)
+    if isinstance(value, bool) or not isinstance(value, (int, float)):
+      return 10.0
+    return max(0.0, float(value))
+
   def _is_balancing_enabled(self):
     """Return whether request balancing is enabled and configured.
 
@@ -362,9 +441,9 @@ class BaseInferenceApiPlugin(
     float
         Minimum-positive stale interval in seconds.
     """
-    value = getattr(self, 'cfg_request_balancing_peer_stale_seconds', 180)
+    value = getattr(self, 'cfg_request_balancing_peer_stale_seconds', 600)
     if isinstance(value, bool) or not isinstance(value, (int, float)):
-      return 180.0
+      return 600.0
     return max(1.0, float(value))
 
   def _get_mailbox_poll_period(self):
@@ -627,13 +706,13 @@ class BaseInferenceApiPlugin(
     self._publish_capacity_record(force=True)
     return
 
-  def _build_capacity_record(self):
-    """Build the advisory capacity record published to peers.
+  def _build_capacity_record_snapshot(self):
+    """Build the stable part of the advisory capacity record.
 
     Returns
     -------
     dict
-        Capacity and readiness information for this plugin instance.
+        Capacity and readiness information without the volatile timestamp.
     """
     capacity_total = self._get_balancing_capacity()
     capacity_used = self._get_capacity_used()
@@ -649,12 +728,60 @@ class BaseInferenceApiPlugin(
       'capacity_used': capacity_used,
       'capacity_free': capacity_free,
       'max_cstore_bytes': self._get_max_cstore_bytes(),
-      'updated_at': self.time(),
       # Keep both fields: capacity_free is numeric slot availability, while
       # accepting_requests is admission/readiness policy and may be false even
       # when slots are physically free, e.g. during serving cold start.
       'accepting_requests': capacity_free > 0,
     }
+
+  def _build_capacity_record(self, updated_at=None):
+    """Build the advisory capacity record published to peers.
+
+    Parameters
+    ----------
+    updated_at : float, optional
+        Timestamp to place in the record. If omitted, the current plugin time
+        is used.
+
+    Returns
+    -------
+    dict
+        Capacity and readiness information for this plugin instance.
+    """
+    record = self._build_capacity_record_snapshot()
+    record['updated_at'] = self.time() if updated_at is None else updated_at
+    return record
+
+  def _should_publish_capacity_snapshot(self, snapshot, now_ts):
+    """Return whether a capacity snapshot should be published now.
+
+    Parameters
+    ----------
+    snapshot : dict
+        Stable capacity record content without ``updated_at``.
+    now_ts : float
+        Current plugin timestamp.
+
+    Returns
+    -------
+    bool
+        `True` when the snapshot is new, changed, or due for periodic refresh.
+    """
+    last_snapshot = self._last_capacity_publish_snapshot
+    if last_snapshot is None:
+      if self._last_capacity_announce <= 0:
+        return True
+      return (now_ts - self._last_capacity_announce) >= self._get_capacity_announce_period()
+
+    if snapshot != last_snapshot:
+      if not self._last_capacity_publish_ok:
+        return (now_ts - self._last_capacity_announce) >= self._get_capacity_announce_period()
+      return (now_ts - self._last_capacity_announce) >= self._get_capacity_debounce_seconds()
+
+    refresh_period = self._get_capacity_refresh_due_seconds()
+    if refresh_period <= 0:
+      return False
+    return (now_ts - self._last_capacity_announce) >= refresh_period
 
   def _publish_capacity_record(self, force=False):
     """Publish local capacity as advisory soft-state.
@@ -662,7 +789,8 @@ class BaseInferenceApiPlugin(
     Parameters
     ----------
     force : bool, optional
-        Publish immediately even when the announce period has not elapsed.
+        Kept for reserve/release call-site compatibility. Capacity publishes
+        are still gated by snapshot changes, debounce, refresh, and retry rules.
 
     Returns
     -------
@@ -671,25 +799,34 @@ class BaseInferenceApiPlugin(
 
     Notes
     -----
-    Capacity records are advisory soft-state, including forced reserve/release
-    publishes. Local `_active_execution_slots` remains the authoritative
-    admission control; peers repair stale capacity views on later announces.
+    Capacity records are advisory soft-state. They are published when the
+    meaningful capacity snapshot changes, when the unchanged snapshot is due
+    for a slow refresh, or when a previous publish has failed and the retry
+    interval has elapsed. Local `_active_execution_slots` remains the
+    authoritative admission control.
     """
     if not self._is_balancing_enabled():
       return
     now_ts = self.time()
-    if (not force) and (now_ts - self._last_capacity_announce) < getattr(
-      self, 'cfg_request_balancing_announce_period', 60
-    ):
+    snapshot = self._build_capacity_record_snapshot()
+    if not self._should_publish_capacity_snapshot(snapshot=snapshot, now_ts=now_ts):
       return
     ok = self.chainstore_hset(
       hkey=self._capacity_hkey(),
       key=self._get_instance_balance_key(),
-      value=self._build_capacity_record(),
+      value={
+        **snapshot,
+        'updated_at': now_ts,
+      },
       timeout=self._get_capacity_cstore_timeout(),
       max_retries=self._get_capacity_cstore_max_retries(),
     )
     self._last_capacity_announce = now_ts
+    self._last_capacity_publish_ok = bool(ok)
+    if ok:
+      self._last_capacity_publish_snapshot = {
+        **snapshot,
+      }
     if not ok:
       warn_period = self._get_capacity_warn_period()
       if warn_period <= 0 or (now_ts - self._last_capacity_warn) >= warn_period:

--- a/extensions/business/edge_inference_api/base_inference_api.py
+++ b/extensions/business/edge_inference_api/base_inference_api.py
@@ -231,6 +231,7 @@ class BaseInferenceApiPlugin(
     self._last_capacity_warn = 0.0
     self._last_capacity_publish_ok = False
     self._last_capacity_publish_snapshot = None
+    self._last_capacity_publish_attempt_snapshot = None
     self._last_balancing_mailbox_poll = 0.0
     self.load_persistence_data()
     tunneling_str = f"(with tunneling enabled)" if self.cfg_tunnel_engine_enabled else ""
@@ -773,15 +774,43 @@ class BaseInferenceApiPlugin(
         return True
       return (now_ts - self._last_capacity_announce) >= self._get_capacity_announce_period()
 
-    if snapshot != last_snapshot:
-      if not self._last_capacity_publish_ok:
+    if self._is_capacity_snapshot_urgent_deterioration(snapshot=snapshot, last_snapshot=last_snapshot):
+      if (
+        not self._last_capacity_publish_ok and
+        self._last_capacity_publish_attempt_snapshot == snapshot
+      ):
         return (now_ts - self._last_capacity_announce) >= self._get_capacity_announce_period()
+      return True
+
+    if not self._last_capacity_publish_ok:
+      return (now_ts - self._last_capacity_announce) >= self._get_capacity_announce_period()
+
+    if snapshot != last_snapshot:
       return (now_ts - self._last_capacity_announce) >= self._get_capacity_debounce_seconds()
 
     refresh_period = self._get_capacity_refresh_due_seconds()
     if refresh_period <= 0:
       return False
     return (now_ts - self._last_capacity_announce) >= refresh_period
+
+  def _is_capacity_snapshot_urgent_deterioration(self, snapshot, last_snapshot):
+    """Return whether peers must stop treating this instance as available.
+
+    Capacity improvements and noisy count changes can be debounced. A transition
+    to no available execution capacity must publish immediately so peers do not
+    keep delegating to an executor that can no longer reserve work.
+    """
+    if not isinstance(snapshot, dict) or not isinstance(last_snapshot, dict):
+      return False
+    accepting_was_true = bool(last_snapshot.get('accepting_requests'))
+    accepting_is_false = not bool(snapshot.get('accepting_requests'))
+    if accepting_was_true and accepting_is_false:
+      return True
+    last_free = last_snapshot.get('capacity_free')
+    current_free = snapshot.get('capacity_free')
+    if isinstance(last_free, (int, float)) and isinstance(current_free, (int, float)):
+      return last_free > 0 and current_free <= 0
+    return False
 
   def _publish_capacity_record(self, force=False):
     """Publish local capacity as advisory soft-state.
@@ -822,6 +851,9 @@ class BaseInferenceApiPlugin(
       max_retries=self._get_capacity_cstore_max_retries(),
     )
     self._last_capacity_announce = now_ts
+    self._last_capacity_publish_attempt_snapshot = {
+      **snapshot,
+    }
     self._last_capacity_publish_ok = bool(ok)
     if ok:
       self._last_capacity_publish_snapshot = {

--- a/extensions/business/edge_inference_api/base_inference_api.py
+++ b/extensions/business/edge_inference_api/base_inference_api.py
@@ -231,6 +231,8 @@ class BaseInferenceApiPlugin(
     self._last_capacity_warn = 0.0
     self._last_capacity_publish_ok = False
     self._last_capacity_publish_snapshot = None
+    # Tracks the last attempted snapshot only to throttle repeated urgent retry
+    # attempts when ChainStore does not confirm publication.
     self._last_capacity_publish_attempt_snapshot = None
     self._last_balancing_mailbox_poll = 0.0
     self.load_persistence_data()
@@ -242,7 +244,7 @@ class BaseInferenceApiPlugin(
     start_msg += f"\t\tAI Engine: {self.cfg_ai_engine}\n"
     start_msg += f"\t\tLoopback key: loopback_dct_{self._stream_id}"
     self.P(start_msg)
-    self._publish_capacity_record(force=True)
+    self._publish_capacity_record()
     return
 
   def _json_dumps(self, data):
@@ -683,7 +685,7 @@ class BaseInferenceApiPlugin(
     if isinstance(request_data, dict):
       request_data['slot_reserved'] = True
       request_data['slot_reserved_at'] = self.time()
-    self._publish_capacity_record(force=True)
+    self._publish_capacity_record()
     return True
 
   def _release_execution_slot(self, request_id):
@@ -704,7 +706,7 @@ class BaseInferenceApiPlugin(
     if isinstance(request_data, dict):
       request_data['slot_reserved'] = False
       request_data['slot_released_at'] = self.time()
-    self._publish_capacity_record(force=True)
+    self._publish_capacity_record()
     return
 
   def _build_capacity_record_snapshot(self):
@@ -756,6 +758,9 @@ class BaseInferenceApiPlugin(
   def _should_publish_capacity_snapshot(self, snapshot, now_ts):
     """Return whether a capacity snapshot should be published now.
 
+    Decision order: first-publish or urgent deterioration, failed-publish retry,
+    changed-snapshot debounce, then unchanged-snapshot periodic refresh.
+
     Parameters
     ----------
     snapshot : dict
@@ -770,6 +775,16 @@ class BaseInferenceApiPlugin(
     """
     last_snapshot = self._last_capacity_publish_snapshot
     if last_snapshot is None:
+      # No successful publish exists yet. Peers should not know this executor
+      # unless a prior unconfirmed attempt was actually observed, so normal
+      # first-publish retries stay announce-period limited. The exception is an
+      # urgent deterioration from the last attempted available snapshot.
+      last_attempt_snapshot = self._last_capacity_publish_attempt_snapshot
+      if self._is_capacity_snapshot_urgent_deterioration(
+        snapshot=snapshot,
+        last_snapshot=last_attempt_snapshot,
+      ):
+        return True
       if self._last_capacity_announce <= 0:
         return True
       return (now_ts - self._last_capacity_announce) >= self._get_capacity_announce_period()
@@ -812,14 +827,8 @@ class BaseInferenceApiPlugin(
       return last_free > 0 and current_free <= 0
     return False
 
-  def _publish_capacity_record(self, force=False):
+  def _publish_capacity_record(self):
     """Publish local capacity as advisory soft-state.
-
-    Parameters
-    ----------
-    force : bool, optional
-        Kept for reserve/release call-site compatibility. Capacity publishes
-        are still gated by snapshot changes, debounce, refresh, and retry rules.
 
     Returns
     -------

--- a/extensions/business/edge_inference_api/test_base_inference_api_balancing.py
+++ b/extensions/business/edge_inference_api/test_base_inference_api_balancing.py
@@ -309,6 +309,37 @@ class BaseInferenceApiBalancingTests(unittest.TestCase):
     self.assertEqual(len(plugin.chainstore_hset_calls), 2)
     self.assertEqual(plugin.chainstore_hset_calls[-1]["value"]["updated_at"], 1000.0)
 
+  def test_failed_unchanged_capacity_refresh_retries_after_announce_period(self):
+    plugin = self._make_plugin(
+      REQUEST_BALANCING_ANNOUNCE_PERIOD=60,
+      REQUEST_BALANCING_CAPACITY_REFRESH_PERIOD=300,
+      REQUEST_BALANCING_CAPACITY_REFRESH_JITTER_SECONDS=0,
+      REQUEST_BALANCING_CAPACITY_WARN_PERIOD=0,
+      NOW=100.0,
+    )
+
+    self.assertEqual(len(plugin.chainstore_hset_calls), 1)
+
+    plugin.chainstore_hset_result = False
+    plugin._now = 400.0  # pylint: disable=protected-access
+    plugin._publish_capacity_record()  # pylint: disable=protected-access
+
+    self.assertEqual(len(plugin.chainstore_hset_calls), 2)
+    self.assertFalse(plugin._last_capacity_publish_ok)  # pylint: disable=protected-access
+
+    plugin._now = 459.0  # pylint: disable=protected-access
+    plugin._publish_capacity_record()  # pylint: disable=protected-access
+
+    self.assertEqual(len(plugin.chainstore_hset_calls), 2)
+
+    plugin.chainstore_hset_result = True
+    plugin._now = 460.0  # pylint: disable=protected-access
+    plugin._publish_capacity_record()  # pylint: disable=protected-access
+
+    self.assertEqual(len(plugin.chainstore_hset_calls), 3)
+    self.assertEqual(plugin.chainstore_hset_calls[-1]["value"]["updated_at"], 460.0)
+    self.assertTrue(plugin._last_capacity_publish_ok)  # pylint: disable=protected-access
+
   def test_capacity_publish_can_disable_unchanged_refresh(self):
     plugin = self._make_plugin(
       REQUEST_BALANCING_CAPACITY_REFRESH_PERIOD=0,
@@ -343,9 +374,25 @@ class BaseInferenceApiBalancingTests(unittest.TestCase):
     self.assertEqual(plugin.chainstore_hset_calls[-1]["value"]["capacity_used"], 1)
     self.assertEqual(plugin.chainstore_hset_calls[-1]["value"]["capacity_free"], 1)
 
-  def test_reserve_release_burst_does_not_republish_same_capacity(self):
+  def test_full_capacity_transition_publishes_immediately_without_debounce(self):
     plugin = self._make_plugin(
       REQUEST_BALANCING_CAPACITY=1,
+      REQUEST_BALANCING_CAPACITY_DEBOUNCE_SECONDS=10,
+      REQUEST_BALANCING_CAPACITY_REFRESH_PERIOD=900,
+      REQUEST_BALANCING_CAPACITY_REFRESH_JITTER_SECONDS=0,
+      NOW=100.0,
+    )
+
+    plugin._now = 101.0  # pylint: disable=protected-access
+    self.assertTrue(plugin._reserve_execution_slot("req-1"))  # pylint: disable=protected-access
+
+    self.assertEqual(len(plugin.chainstore_hset_calls), 2)
+    self.assertEqual(plugin.chainstore_hset_calls[-1]["value"]["capacity_free"], 0)
+    self.assertFalse(plugin.chainstore_hset_calls[-1]["value"]["accepting_requests"])
+
+  def test_reserve_release_burst_does_not_republish_non_urgent_capacity(self):
+    plugin = self._make_plugin(
+      REQUEST_BALANCING_CAPACITY=2,
       REQUEST_BALANCING_CAPACITY_DEBOUNCE_SECONDS=10,
       REQUEST_BALANCING_CAPACITY_REFRESH_PERIOD=900,
       REQUEST_BALANCING_CAPACITY_REFRESH_JITTER_SECONDS=0,

--- a/extensions/business/edge_inference_api/test_base_inference_api_balancing.py
+++ b/extensions/business/edge_inference_api/test_base_inference_api_balancing.py
@@ -114,8 +114,10 @@ class _FakeBasePlugin:
     import hashlib
     if algorithm == 'sha256':
       value = hashlib.sha256(str_data.encode("utf-8")).hexdigest()
-    else:
+    elif algorithm == 'md5':
       value = hashlib.md5(str_data.encode("utf-8")).hexdigest()
+    else:
+      raise NotImplementedError(f"Unsupported hash algorithm in test fake: {algorithm}")
     return value[:length] if length is not None else value
 
   @property
@@ -284,7 +286,7 @@ class BaseInferenceApiBalancingTests(unittest.TestCase):
     self.assertEqual(plugin._last_capacity_announce, 100.0)  # pylint: disable=protected-access
 
     plugin._now = 101.0  # pylint: disable=protected-access
-    plugin._publish_capacity_record(force=True)  # pylint: disable=protected-access
+    plugin._publish_capacity_record()  # pylint: disable=protected-access
 
     self.assertEqual(len(plugin.logs), first_log_count)
     self.assertEqual(plugin._last_capacity_announce, 101.0)  # pylint: disable=protected-access
@@ -299,7 +301,7 @@ class BaseInferenceApiBalancingTests(unittest.TestCase):
     self.assertEqual(len(plugin.chainstore_hset_calls), 1)
 
     plugin._now = 500.0  # pylint: disable=protected-access
-    plugin._publish_capacity_record(force=True)  # pylint: disable=protected-access
+    plugin._publish_capacity_record()  # pylint: disable=protected-access
 
     self.assertEqual(len(plugin.chainstore_hset_calls), 1)
 
@@ -363,12 +365,12 @@ class BaseInferenceApiBalancingTests(unittest.TestCase):
 
     plugin._active_execution_slots.add("req-1")  # pylint: disable=protected-access
     plugin._now = 105.0  # pylint: disable=protected-access
-    plugin._publish_capacity_record(force=True)  # pylint: disable=protected-access
+    plugin._publish_capacity_record()  # pylint: disable=protected-access
 
     self.assertEqual(len(plugin.chainstore_hset_calls), 1)
 
     plugin._now = 110.0  # pylint: disable=protected-access
-    plugin._publish_capacity_record(force=True)  # pylint: disable=protected-access
+    plugin._publish_capacity_record()  # pylint: disable=protected-access
 
     self.assertEqual(len(plugin.chainstore_hset_calls), 2)
     self.assertEqual(plugin.chainstore_hset_calls[-1]["value"]["capacity_used"], 1)
@@ -389,6 +391,37 @@ class BaseInferenceApiBalancingTests(unittest.TestCase):
     self.assertEqual(len(plugin.chainstore_hset_calls), 2)
     self.assertEqual(plugin.chainstore_hset_calls[-1]["value"]["capacity_free"], 0)
     self.assertFalse(plugin.chainstore_hset_calls[-1]["value"]["accepting_requests"])
+
+  def test_failed_first_available_publish_allows_immediate_full_capacity_publish(self):
+    plugin = self._make_plugin(
+      CHAINSTORE_HSET_RESULT=False,
+      REQUEST_BALANCING_CAPACITY=1,
+      REQUEST_BALANCING_ANNOUNCE_PERIOD=60,
+      REQUEST_BALANCING_CAPACITY_DEBOUNCE_SECONDS=10,
+      REQUEST_BALANCING_CAPACITY_REFRESH_PERIOD=900,
+      REQUEST_BALANCING_CAPACITY_REFRESH_JITTER_SECONDS=0,
+      NOW=100.0,
+    )
+
+    self.assertEqual(len(plugin.chainstore_hset_calls), 1)
+    self.assertIsNone(plugin._last_capacity_publish_snapshot)  # pylint: disable=protected-access
+    self.assertEqual(
+      plugin._last_capacity_publish_attempt_snapshot["capacity_free"],  # pylint: disable=protected-access
+      1,
+    )
+
+    plugin._now = 101.0  # pylint: disable=protected-access
+    self.assertTrue(plugin._reserve_execution_slot("req-1"))  # pylint: disable=protected-access
+
+    self.assertEqual(len(plugin.chainstore_hset_calls), 2)
+    self.assertEqual(plugin.chainstore_hset_calls[-1]["value"]["updated_at"], 101.0)
+    self.assertEqual(plugin.chainstore_hset_calls[-1]["value"]["capacity_free"], 0)
+    self.assertFalse(plugin.chainstore_hset_calls[-1]["value"]["accepting_requests"])
+
+    plugin._now = 102.0  # pylint: disable=protected-access
+    plugin._publish_capacity_record()  # pylint: disable=protected-access
+
+    self.assertEqual(len(plugin.chainstore_hset_calls), 2)
 
   def test_reserve_release_burst_does_not_republish_non_urgent_capacity(self):
     plugin = self._make_plugin(

--- a/extensions/business/edge_inference_api/test_base_inference_api_balancing.py
+++ b/extensions/business/edge_inference_api/test_base_inference_api_balancing.py
@@ -32,7 +32,16 @@ class _FakeBasePlugin:
     self.cfg_request_balancing_capacity = kwargs.get("REQUEST_BALANCING_CAPACITY", 1)
     self.cfg_request_balancing_pending_limit = kwargs.get("REQUEST_BALANCING_PENDING_LIMIT", 8)
     self.cfg_request_balancing_announce_period = kwargs.get("REQUEST_BALANCING_ANNOUNCE_PERIOD", 60)
-    self.cfg_request_balancing_peer_stale_seconds = kwargs.get("REQUEST_BALANCING_PEER_STALE_SECONDS", 180)
+    self.cfg_request_balancing_capacity_refresh_period = kwargs.get(
+      "REQUEST_BALANCING_CAPACITY_REFRESH_PERIOD", 300
+    )
+    self.cfg_request_balancing_capacity_refresh_jitter_seconds = kwargs.get(
+      "REQUEST_BALANCING_CAPACITY_REFRESH_JITTER_SECONDS", 120
+    )
+    self.cfg_request_balancing_capacity_debounce_seconds = kwargs.get(
+      "REQUEST_BALANCING_CAPACITY_DEBOUNCE_SECONDS", 10
+    )
+    self.cfg_request_balancing_peer_stale_seconds = kwargs.get("REQUEST_BALANCING_PEER_STALE_SECONDS", 600)
     self.cfg_request_balancing_mailbox_poll_period = kwargs.get("REQUEST_BALANCING_MAILBOX_POLL_PERIOD", 1)
     self.cfg_request_balancing_capacity_cstore_timeout = kwargs.get(
       "REQUEST_BALANCING_CAPACITY_CSTORE_TIMEOUT", 2
@@ -99,6 +108,15 @@ class _FakeBasePlugin:
 
   def json_loads(self, data):
     return json.loads(data)
+
+  @staticmethod
+  def get_hash(str_data, length=None, algorithm='md5'):
+    import hashlib
+    if algorithm == 'sha256':
+      value = hashlib.sha256(str_data.encode("utf-8")).hexdigest()
+    else:
+      value = hashlib.md5(str_data.encode("utf-8")).hexdigest()
+    return value[:length] if length is not None else value
 
   @property
   def np(self):
@@ -271,6 +289,88 @@ class BaseInferenceApiBalancingTests(unittest.TestCase):
     self.assertEqual(len(plugin.logs), first_log_count)
     self.assertEqual(plugin._last_capacity_announce, 101.0)  # pylint: disable=protected-access
 
+  def test_capacity_publish_skips_unchanged_record_until_refresh_period(self):
+    plugin = self._make_plugin(
+      REQUEST_BALANCING_CAPACITY_REFRESH_PERIOD=900,
+      REQUEST_BALANCING_CAPACITY_REFRESH_JITTER_SECONDS=0,
+      NOW=100.0,
+    )
+
+    self.assertEqual(len(plugin.chainstore_hset_calls), 1)
+
+    plugin._now = 500.0  # pylint: disable=protected-access
+    plugin._publish_capacity_record(force=True)  # pylint: disable=protected-access
+
+    self.assertEqual(len(plugin.chainstore_hset_calls), 1)
+
+    plugin._now = 1000.0  # pylint: disable=protected-access
+    plugin._publish_capacity_record()  # pylint: disable=protected-access
+
+    self.assertEqual(len(plugin.chainstore_hset_calls), 2)
+    self.assertEqual(plugin.chainstore_hset_calls[-1]["value"]["updated_at"], 1000.0)
+
+  def test_capacity_publish_can_disable_unchanged_refresh(self):
+    plugin = self._make_plugin(
+      REQUEST_BALANCING_CAPACITY_REFRESH_PERIOD=0,
+      REQUEST_BALANCING_CAPACITY_REFRESH_JITTER_SECONDS=120,
+      NOW=100.0,
+    )
+
+    plugin._now = 10_000.0  # pylint: disable=protected-access
+    plugin._publish_capacity_record()  # pylint: disable=protected-access
+
+    self.assertEqual(len(plugin.chainstore_hset_calls), 1)
+
+  def test_capacity_publish_debounces_changed_capacity_snapshot(self):
+    plugin = self._make_plugin(
+      REQUEST_BALANCING_CAPACITY=2,
+      REQUEST_BALANCING_CAPACITY_DEBOUNCE_SECONDS=10,
+      REQUEST_BALANCING_CAPACITY_REFRESH_PERIOD=900,
+      REQUEST_BALANCING_CAPACITY_REFRESH_JITTER_SECONDS=0,
+      NOW=100.0,
+    )
+
+    plugin._active_execution_slots.add("req-1")  # pylint: disable=protected-access
+    plugin._now = 105.0  # pylint: disable=protected-access
+    plugin._publish_capacity_record(force=True)  # pylint: disable=protected-access
+
+    self.assertEqual(len(plugin.chainstore_hset_calls), 1)
+
+    plugin._now = 110.0  # pylint: disable=protected-access
+    plugin._publish_capacity_record(force=True)  # pylint: disable=protected-access
+
+    self.assertEqual(len(plugin.chainstore_hset_calls), 2)
+    self.assertEqual(plugin.chainstore_hset_calls[-1]["value"]["capacity_used"], 1)
+    self.assertEqual(plugin.chainstore_hset_calls[-1]["value"]["capacity_free"], 1)
+
+  def test_reserve_release_burst_does_not_republish_same_capacity(self):
+    plugin = self._make_plugin(
+      REQUEST_BALANCING_CAPACITY=1,
+      REQUEST_BALANCING_CAPACITY_DEBOUNCE_SECONDS=10,
+      REQUEST_BALANCING_CAPACITY_REFRESH_PERIOD=900,
+      REQUEST_BALANCING_CAPACITY_REFRESH_JITTER_SECONDS=0,
+      NOW=100.0,
+    )
+
+    plugin._now = 101.0  # pylint: disable=protected-access
+    self.assertTrue(plugin._reserve_execution_slot("req-1"))  # pylint: disable=protected-access
+    plugin._now = 102.0  # pylint: disable=protected-access
+    plugin._release_execution_slot("req-1")  # pylint: disable=protected-access
+
+    self.assertEqual(len(plugin.chainstore_hset_calls), 1)
+
+  def test_capacity_refresh_jitter_is_stable_per_instance(self):
+    plugin = self._make_plugin(
+      REQUEST_BALANCING_CAPACITY_REFRESH_PERIOD=300,
+      REQUEST_BALANCING_CAPACITY_REFRESH_JITTER_SECONDS=120,
+    )
+
+    due_seconds = plugin._get_capacity_refresh_due_seconds()  # pylint: disable=protected-access
+
+    self.assertGreaterEqual(due_seconds, 300.0)
+    self.assertLessEqual(due_seconds, 420.0)
+    self.assertEqual(due_seconds, plugin._get_capacity_refresh_due_seconds())  # pylint: disable=protected-access
+
   def test_select_execution_peer_prefers_highest_capacity_free_and_ignores_stale(self):
     plugin = self._make_plugin()
     plugin.chainstore_hgetall_values[plugin._capacity_hkey()] = {
@@ -281,7 +381,7 @@ class BaseInferenceApiBalancingTests(unittest.TestCase):
         "capacity_total": 2,
         "capacity_used": 0,
         "capacity_free": 2,
-        "updated_at": plugin.time() - 999,
+        "updated_at": plugin.time() - 9999,
       },
       "peer-one": {
         "ee_addr": "peer-one",


### PR DESCRIPTION
What changed:
- Gate capacity publishes by stable snapshot changes, debounce bursts, and periodic unchanged refreshes with per-instance jitter.
- Keep capacity CStore writes short-lived soft-state attempts with retry scheduling after failures.
- Retry failed unchanged refreshes on `REQUEST_BALANCING_ANNOUNCE_PERIOD` instead of the full refresh period.
- Publish urgent availability deterioration immediately, including the case where the first available publish was unconfirmed and the instance becomes full before the announce retry window.
- Remove the misleading `force` parameter from capacity publishing and call sites.
- Add regression coverage for unchanged refresh, failed retry, urgent full-capacity transition, debounce, jitter, and reserve/release burst behavior.

Operational note:
- Recovery from full capacity (`capacity_free: 0` to positive) remains debounced by `REQUEST_BALANCING_CAPACITY_DEBOUNCE_SECONDS`. This intentionally favors lower CStore write volume over immediate re-advertisement of newly freed slots.

Why:
- Reduce avoidable ChainStore/MQTT traffic from inference capacity announcements without coupling the fix to RobotFactory work.
- Avoid stale peer views that keep routing work to an executor that just became unavailable.