### PR TITLE
fix: keep container cleanup recoverable

### DIFF
--- a/extensions/business/container_apps/container_app_runner.py
+++ b/extensions/business/container_apps/container_app_runner.py
@@ -1506,7 +1506,7 @@ class ContainerAppRunnerPlugin(
         return None
       try:
         pid_names = os.listdir(proc_root)
-      except Exception as exc:
+      except OSError as exc:
         self.P(f"Could not inspect {label} process group {pgid}: {exc}", color='r')
         return None
 
@@ -1524,10 +1524,11 @@ class ContainerAppRunnerPlugin(
           continue
         except Exception as exc:
           self.P(f"Could not inspect {label} process {pid_name}: {exc}", color='r')
-          return None
+          continue
         if member_pgid != pgid:
           continue
         found_member = True
+        # Stopped/traced members can resume later, so only zombies are treated as inert.
         if state != "Z":
           return True
       return False if found_member else None
@@ -1609,14 +1610,12 @@ class ContainerAppRunnerPlugin(
     cleanup state forever. A stale live tunnel can disappear later, and the app
     should self-heal without requiring a node restart.
     """
-    probe_delay = max(
-      1.0,
-      float(
-        self.cfg_restart_backoff_max
-        or self.cfg_restart_backoff_initial
-        or 1.0
-      )
-    )
+    configured_delay = self.cfg_restart_backoff_max
+    if configured_delay is None:
+      configured_delay = self.cfg_restart_backoff_initial
+    if configured_delay is None:
+      configured_delay = 1.0
+    probe_delay = max(1.0, float(configured_delay))
     self._restart_backoff_seconds = probe_delay
     self._next_restart_time = self.time() + probe_delay
     self.Pd(
@@ -3863,6 +3862,11 @@ class ContainerAppRunnerPlugin(
       if cleanup_ok:
         self._cleanup_failed = False
         self._cleanup_retry_abandoned_logged = False
+        # Cleanup recovered after max-retry abandonment; clear retry accounting before relaunch.
+        self._consecutive_failures = 0
+        self._last_failure_time = 0
+        self._restart_backoff_seconds = 0
+        self._next_restart_time = 0
         self.P("Previously abandoned container cleanup succeeded.", color='g')
         if self._manual_stop_pending:
           self._save_persistent_state(manually_stopped=True)

--- a/extensions/business/container_apps/container_app_runner.py
+++ b/extensions/business/container_apps/container_app_runner.py
@@ -604,6 +604,7 @@ class ContainerAppRunnerPlugin(
     self.container_state = ContainerState.UNINITIALIZED
     self.stop_reason = StopReason.UNKNOWN
     self._cleanup_failed = False
+    self._cleanup_retry_abandoned_logged = False
     self._manual_stop_pending = False
 
     # Restart policy and retry logic
@@ -1480,36 +1481,71 @@ class ContainerAppRunnerPlugin(
 
   def _terminate_subprocess_tree(self, process, label="subprocess", terminate_timeout=5, kill_timeout=5):
     """
-    Terminate a tunnel subprocess tree with a compatibility fallback.
+    Terminate a tunnel subprocess tree with edge-local compatibility behavior.
 
-    Prefer the core implementation when present; otherwise use the same bounded
-    POSIX process-group shutdown strategy locally so mixed-version deployments
-    do not leak extra tunnel children.
+    Keep this implementation local instead of delegating to core. Deployed edge
+    images can temporarily run with an older core that has a process-group helper
+    but does not understand zombie-only tunnel groups, which was enough to keep
+    cleanup permanently latched on drs1.
     """
-    base_method = getattr(super(ContainerAppRunnerPlugin, self), "_terminate_subprocess_tree", None)
-    if callable(base_method):
-      return base_method(
-        process,
-        label=label,
-        terminate_timeout=terminate_timeout,
-        kill_timeout=kill_timeout,
-      )
     if process is None:
       return True
 
     pgid = getattr(process, "_r1_process_group_id", None)
+
+    def process_group_has_live_members():
+      """
+      Return True only when the process group still has non-zombie members.
+
+      POSIX reports zombie members through ``killpg(pgid, 0)`` until their
+      parent reaps them. Zombie-only tunnel groups cannot serve traffic or be
+      killed again, so treating them as alive would keep cleanup retries stuck.
+      """
+      proc_root = "/proc"
+      if os.name == "nt" or pgid is None or not os.path.isdir(proc_root):
+        return None
+      try:
+        pid_names = os.listdir(proc_root)
+      except Exception as exc:
+        self.P(f"Could not inspect {label} process group {pgid}: {exc}", color='r')
+        return None
+
+      found_member = False
+      for pid_name in pid_names:
+        if not pid_name.isdigit():
+          continue
+        try:
+          with open(os.path.join(proc_root, pid_name, "stat"), "r") as fh:
+            stat = fh.read()
+          stat_tail = stat.rsplit(")", 1)[1].strip().split()
+          state = stat_tail[0]
+          member_pgid = int(stat_tail[2])
+        except (FileNotFoundError, ProcessLookupError, IndexError, ValueError):
+          continue
+        except Exception as exc:
+          self.P(f"Could not inspect {label} process {pid_name}: {exc}", color='r')
+          return None
+        if member_pgid != pgid:
+          continue
+        found_member = True
+        if state != "Z":
+          return True
+      return False if found_member else None
 
     def is_process_group_alive():
       if os.name == "nt" or pgid is None:
         return False
       try:
         os.killpg(pgid, 0)
-        return True
       except ProcessLookupError:
         return False
       except Exception as exc:
         self.P(f"Could not probe {label} process group {pgid}: {exc}", color='r')
         return True
+      live_members = process_group_has_live_members()
+      if live_members is not None:
+        return live_members
+      return True
 
     def wait_process_tree(timeout):
       deadline = time.monotonic() + timeout
@@ -1563,6 +1599,30 @@ class ContainerAppRunnerPlugin(
       return True
     self.P(f"{label} did not exit after kill; continuing shutdown.", color='r')
     return False
+
+
+  def _schedule_abandoned_cleanup_probe(self):
+    """
+    Schedule a low-noise cleanup probe after retry exhaustion.
+
+    Max restart retries should stop aggressive relaunch attempts, not freeze the
+    cleanup state forever. A stale live tunnel can disappear later, and the app
+    should self-heal without requiring a node restart.
+    """
+    probe_delay = max(
+      1.0,
+      float(
+        self.cfg_restart_backoff_max
+        or self.cfg_restart_backoff_initial
+        or 1.0
+      )
+    )
+    self._restart_backoff_seconds = probe_delay
+    self._next_restart_time = self.time() + probe_delay
+    self.Pd(
+      "Abandoned cleanup probe scheduled in {:.1f}s".format(probe_delay)
+    )
+    return
 
 
   def stop_tunnel_engine(self):
@@ -1949,13 +2009,13 @@ class ContainerAppRunnerPlugin(
       # Read remaining logs before stopping
       self._read_extra_tunnel_logs(container_port)
 
-      # Stop process
-      if process.poll() is None:  # Still running
-        process_stopped = self._terminate_subprocess_tree(
-          process,
-          label=f"Extra tunnel for port {container_port}",
-        )
-        result = process_stopped and result
+      # Stop the recorded process group even if the Popen parent has exited:
+      # shell wrappers can leave live tunnel descendants behind.
+      process_stopped = self._terminate_subprocess_tree(
+        process,
+        label=f"Extra tunnel for port {container_port}",
+      )
+      result = process_stopped and result
 
       # Clean up log readers (following base class pattern)
       log_readers = self.extra_tunnel_log_readers.get(container_port, {})
@@ -2936,8 +2996,9 @@ class ContainerAppRunnerPlugin(
     Returns
     -------
     bool
-      True when the Docker container is stopped/removed or absent, False when
-      Docker reported a failure.
+      True when all runtime cleanup steps completed. False can mean either the
+      Docker container may still be present (tracked by ``_runtime_stop_degraded``)
+      or a sidecar/log-reader step still needs retry after Docker removal.
     """
     self.P(f"Stopping container app '{self.container_id}' ...")
 
@@ -3039,8 +3100,18 @@ class ContainerAppRunnerPlugin(
     runtime_ok = self._stop_container_runtime_for_restart()
     cleanup_errors = []
 
-    if runtime_ok:
+    if runtime_ok or not self._runtime_stop_degraded:
       try:
+        if not runtime_ok:
+          # Fixed-size volume mutation only depends on the Docker container no
+          # longer owning the mount. Tunnel/log-reader failures remain retryable,
+          # but they should not keep loop devices mounted after Docker removal.
+          cleanup_errors.append("runtime")
+          self.P(
+            "Fixed-size volume cleanup is safe because Docker container stop/remove "
+            "succeeded; runtime sidecar cleanup still needs retry.",
+            color='y',
+          )
         if self._cleanup_fixed_size_volumes() is False:
           cleanup_errors.append("fixed-size volumes")
       except Exception as exc:
@@ -3067,9 +3138,11 @@ class ContainerAppRunnerPlugin(
 
     if cleanup_errors:
       self._cleanup_failed = True
+      self._cleanup_retry_abandoned_logged = False
       self.P("Container cleanup completed with failed step(s): {}.".format(", ".join(cleanup_errors)), color='r')
       return False
     self._cleanup_failed = False
+    self._cleanup_retry_abandoned_logged = False
     return True
 
 
@@ -3775,12 +3848,30 @@ class ContainerAppRunnerPlugin(
       return True
 
     if self._has_exceeded_max_retries():
-      self.P(
-        "Container cleanup retry abandoned after {} consecutive failure(s).".format(
-          self._consecutive_failures
-        ),
-        color='r',
-      )
+      if not self._cleanup_retry_abandoned_logged:
+        self.P(
+          "Container cleanup retry abandoned after {} consecutive failure(s).".format(
+            self._consecutive_failures
+          ),
+          color='r',
+        )
+        self._cleanup_retry_abandoned_logged = True
+      if self._is_restart_backoff_active():
+        return False
+      self.P("Rechecking abandoned container cleanup after backoff...", color='y')
+      cleanup_ok = self._stop_container_and_save_logs_to_disk()
+      if cleanup_ok:
+        self._cleanup_failed = False
+        self._cleanup_retry_abandoned_logged = False
+        self.P("Previously abandoned container cleanup succeeded.", color='g')
+        if self._manual_stop_pending:
+          self._save_persistent_state(manually_stopped=True)
+          self._manual_stop_pending = False
+          self._set_container_state(ContainerState.PAUSED, StopReason.MANUAL_STOP)
+          return False
+        return True
+      self._schedule_abandoned_cleanup_probe()
+      self._set_container_state(ContainerState.FAILED, self.stop_reason or StopReason.UNKNOWN)
       return False
 
     if self._is_restart_backoff_active():

--- a/extensions/business/container_apps/tests/support.py
+++ b/extensions/business/container_apps/tests/support.py
@@ -109,6 +109,11 @@ class _DummyBasePlugin:
   def stop_tunnel_command(self, *args, **kwargs):
     return
 
+  def _terminate_subprocess_tree(self, *args, **kwargs):
+    # Tests ensure CAR keeps its own mixed-version fallback instead of trusting
+    # whatever tunnel cleanup helper an older core happens to expose.
+    return False
+
   def run_tunnel_engine(self):
     return None
 
@@ -262,6 +267,7 @@ def make_container_app_runner():
   plugin._normalized_exposed_ports = {}
   plugin._normalized_main_exposed_port = None
   plugin._cleanup_failed = False
+  plugin._cleanup_retry_abandoned_logged = False
   plugin._manual_stop_pending = False
   plugin.container = object()
   plugin.container_name = "car_instance"
@@ -367,6 +373,7 @@ def make_lifecycle_runner(docker_client=None, mock_container=None, **cfg_overrid
   plugin.container_state = ContainerState.UNINITIALIZED
   plugin.stop_reason = StopReason.UNKNOWN
   plugin._cleanup_failed = False
+  plugin._cleanup_retry_abandoned_logged = False
   plugin._manual_stop_pending = False
 
   # Restart/backoff

--- a/extensions/business/container_apps/tests/test_container_lifecycle.py
+++ b/extensions/business/container_apps/tests/test_container_lifecycle.py
@@ -497,6 +497,23 @@ class TestLifecycleStop(unittest.TestCase):
     plugin._cleanup_fixed_size_volumes.assert_not_called()
     plugin.diskapi_save_pickle_to_data.assert_called_once()
 
+  def test_stop_and_save_logs_cleans_volumes_when_only_sidecar_cleanup_failed(self):
+    plugin, _, container = self._launch()
+    plugin.stop_tunnel_engine = MagicMock(return_value=False)
+    plugin.stop_extra_tunnels = MagicMock(return_value=True)
+    plugin.diskapi_save_pickle_to_data = MagicMock()
+    plugin._cleanup_fixed_size_volumes = MagicMock(return_value=True)
+
+    result = plugin._stop_container_and_save_logs_to_disk()
+
+    self.assertFalse(result)
+    self.assertTrue(plugin._cleanup_failed)
+    self.assertFalse(plugin._runtime_stop_degraded)
+    container.remove.assert_called_once()
+    plugin._cleanup_fixed_size_volumes.assert_called_once()
+    messages = "\n".join(plugin.logged_messages)
+    self.assertIn("runtime sidecar cleanup still needs retry", messages)
+
   def test_on_close_stops_container(self):
     plugin, _, container = self._launch()
     plugin.on_close()
@@ -636,6 +653,63 @@ class TestLifecycleProcess(unittest.TestCase):
     errors = [m for m in plugin.logged_messages if "abandoned" in m.lower()]
     self.assertTrue(len(errors) > 0)
 
+  def test_failed_cleanup_abandonment_logs_once(self):
+    clock = {"now": 100}
+    plugin, _, _ = make_lifecycle_runner(cfg_restart_max_retries=2)
+    plugin.time = lambda: clock["now"]
+    plugin._cleanup_failed = True
+    plugin._consecutive_failures = 2
+    plugin._next_restart_time = 200
+    plugin.container_state = ContainerState.FAILED
+
+    plugin.process()
+    clock["now"] += 1
+    plugin.process()
+
+    errors = [
+      m for m in plugin.logged_messages
+      if "Container cleanup retry abandoned" in m
+    ]
+    self.assertEqual(len(errors), 1)
+
+  def test_abandoned_cleanup_retries_after_backoff_then_restarts(self):
+    clock = {"now": 100}
+    plugin, client, _ = make_lifecycle_runner(cfg_restart_max_retries=2)
+    plugin.time = lambda: clock["now"]
+    plugin._cleanup_failed = True
+    plugin._consecutive_failures = 2
+    plugin._next_restart_time = 90
+    plugin.container_state = ContainerState.FAILED
+    plugin._stop_container_and_save_logs_to_disk = MagicMock(return_value=True)
+
+    plugin.process()
+
+    self.assertFalse(plugin._cleanup_failed)
+    plugin._stop_container_and_save_logs_to_disk.assert_called_once()
+    client.containers.run.assert_called_once()
+    self.assertEqual(plugin.container_state, ContainerState.RUNNING)
+
+  def test_abandoned_cleanup_failure_schedules_future_probe_without_incrementing_failures(self):
+    clock = {"now": 100}
+    plugin, client, _ = make_lifecycle_runner(
+      cfg_restart_max_retries=2,
+      cfg_restart_backoff_max=60,
+    )
+    plugin.time = lambda: clock["now"]
+    plugin._cleanup_failed = True
+    plugin._consecutive_failures = 2
+    plugin._next_restart_time = 90
+    plugin.container_state = ContainerState.FAILED
+    plugin._stop_container_and_save_logs_to_disk = MagicMock(return_value=False)
+
+    plugin.process()
+
+    self.assertTrue(plugin._cleanup_failed)
+    self.assertEqual(plugin._consecutive_failures, 2)
+    self.assertEqual(plugin._next_restart_time, 160)
+    plugin._stop_container_and_save_logs_to_disk.assert_called_once()
+    client.containers.run.assert_not_called()
+
   def test_process_retries_failed_cleanup_then_restarts(self):
     """A transient cleanup failure must not permanently block process()."""
     clock = {"now": 100}
@@ -774,6 +848,37 @@ class _FakeProcess:
     return 0
 
 
+class _StoppedProcess:
+  def __init__(self, pgid):
+    self.pid = pgid
+    self._r1_process_group_id = pgid
+    self.terminated = False
+    self.killed = False
+
+  def poll(self):
+    return 0
+
+  def terminate(self):
+    self.terminated = True
+    return
+
+  def kill(self):
+    self.killed = True
+    return
+
+  def wait(self, timeout=None):
+    return 0
+
+
+def _fake_proc_stat_open(proc_entries):
+  def fake_open(path, *args, **kwargs):
+    pid_name = Path(path).parent.name
+    state, pgid = proc_entries[pid_name]
+    stat = f"{pid_name} (cloudflared) {state} 1 {pgid} 0 0\n"
+    return MagicMock(__enter__=lambda self: self, __exit__=lambda *args: None, read=lambda: stat)
+  return fake_open
+
+
 class TestTunnelCompatibilityFallbacks(unittest.TestCase):
   """The edge PR must work even before the matching core PR is deployed."""
 
@@ -786,6 +891,56 @@ class TestTunnelCompatibilityFallbacks(unittest.TestCase):
 
     self.assertTrue(process.terminated)
     self.assertTrue(process.killed)
+
+  def test_local_subprocess_fallback_treats_zombie_only_group_as_stopped(self):
+    plugin, _, _ = make_lifecycle_runner()
+    process = _StoppedProcess(pgid=123)
+    proc_entries = {"456": ("Z", 123)}
+
+    with patch("extensions.business.container_apps.container_app_runner.os.name", "posix"), \
+         patch("extensions.business.container_apps.container_app_runner.os.path.isdir", return_value=True), \
+         patch("extensions.business.container_apps.container_app_runner.os.listdir", return_value=list(proc_entries)), \
+         patch("extensions.business.container_apps.container_app_runner.os.killpg", return_value=None), \
+         patch("builtins.open", _fake_proc_stat_open(proc_entries)):
+      self.assertTrue(plugin._terminate_subprocess_tree(process, terminate_timeout=0, kill_timeout=0))
+
+    self.assertFalse(process.terminated)
+    self.assertFalse(process.killed)
+
+  def test_local_subprocess_fallback_keeps_live_group_failed(self):
+    plugin, _, _ = make_lifecycle_runner()
+    process = _StoppedProcess(pgid=123)
+    proc_entries = {"456": ("S", 123)}
+
+    with patch("extensions.business.container_apps.container_app_runner.os.name", "posix"), \
+         patch("extensions.business.container_apps.container_app_runner.os.path.isdir", return_value=True), \
+         patch("extensions.business.container_apps.container_app_runner.os.listdir", return_value=list(proc_entries)), \
+         patch("extensions.business.container_apps.container_app_runner.os.killpg", return_value=None), \
+         patch("builtins.open", _fake_proc_stat_open(proc_entries)):
+      self.assertFalse(plugin._terminate_subprocess_tree(process, terminate_timeout=0, kill_timeout=0))
+
+    self.assertFalse(process.terminated)
+    self.assertFalse(process.killed)
+
+  def test_extra_tunnel_stopped_parent_with_live_descendant_is_preserved(self):
+    plugin, _, _ = make_lifecycle_runner()
+    process = _StoppedProcess(pgid=123)
+    proc_entries = {"456": ("S", 123)}
+    plugin.extra_tunnel_processes = {8080: process}
+    plugin.extra_tunnel_log_readers = {8080: {}}
+    plugin.extra_tunnel_urls = {8080: "https://example.test"}
+    plugin.extra_tunnel_start_times = {8080: 10}
+
+    with patch("extensions.business.container_apps.container_app_runner.os.name", "posix"), \
+         patch("extensions.business.container_apps.container_app_runner.os.path.isdir", return_value=True), \
+         patch("extensions.business.container_apps.container_app_runner.os.listdir", return_value=list(proc_entries)), \
+         patch("extensions.business.container_apps.container_app_runner.os.killpg", return_value=None), \
+         patch("builtins.open", _fake_proc_stat_open(proc_entries)):
+      self.assertFalse(plugin._stop_extra_tunnel(8080))
+
+    self.assertIn(8080, plugin.extra_tunnel_processes)
+    self.assertIn(8080, plugin.extra_tunnel_log_readers)
+    self.assertIn(8080, plugin.extra_tunnel_urls)
 
 
 # ===========================================================================

--- a/extensions/business/container_apps/tests/test_container_lifecycle.py
+++ b/extensions/business/container_apps/tests/test_container_lifecycle.py
@@ -688,6 +688,9 @@ class TestLifecycleProcess(unittest.TestCase):
     plugin._stop_container_and_save_logs_to_disk.assert_called_once()
     client.containers.run.assert_called_once()
     self.assertEqual(plugin.container_state, ContainerState.RUNNING)
+    self.assertEqual(plugin._consecutive_failures, 0)
+    self.assertEqual(plugin._restart_backoff_seconds, 0)
+    self.assertEqual(plugin._next_restart_time, 0)
 
   def test_abandoned_cleanup_failure_schedules_future_probe_without_incrementing_failures(self):
     clock = {"now": 100}
@@ -709,6 +712,19 @@ class TestLifecycleProcess(unittest.TestCase):
     self.assertEqual(plugin._next_restart_time, 160)
     plugin._stop_container_and_save_logs_to_disk.assert_called_once()
     client.containers.run.assert_not_called()
+
+  def test_abandoned_cleanup_probe_respects_zero_max_backoff(self):
+    clock = {"now": 100}
+    plugin, _, _ = make_lifecycle_runner(
+      cfg_restart_backoff_initial=30,
+      cfg_restart_backoff_max=0,
+    )
+    plugin.time = lambda: clock["now"]
+
+    plugin._schedule_abandoned_cleanup_probe()
+
+    self.assertEqual(plugin._restart_backoff_seconds, 1.0)
+    self.assertEqual(plugin._next_restart_time, 101.0)
 
   def test_process_retries_failed_cleanup_then_restarts(self):
     """A transient cleanup failure must not permanently block process()."""
@@ -873,7 +889,12 @@ class _StoppedProcess:
 def _fake_proc_stat_open(proc_entries):
   def fake_open(path, *args, **kwargs):
     pid_name = Path(path).parent.name
-    state, pgid = proc_entries[pid_name]
+    if pid_name not in proc_entries:
+      raise FileNotFoundError(path)
+    entry = proc_entries[pid_name]
+    if isinstance(entry, Exception):
+      raise entry
+    state, pgid = entry
     stat = f"{pid_name} (cloudflared) {state} 1 {pgid} 0 0\n"
     return MagicMock(__enter__=lambda self: self, __exit__=lambda *args: None, read=lambda: stat)
   return fake_open
@@ -922,22 +943,107 @@ class TestTunnelCompatibilityFallbacks(unittest.TestCase):
     self.assertFalse(process.terminated)
     self.assertFalse(process.killed)
 
-  def test_extra_tunnel_stopped_parent_with_live_descendant_is_preserved(self):
+  def test_local_subprocess_fallback_keeps_mixed_group_failed(self):
     plugin, _, _ = make_lifecycle_runner()
     process = _StoppedProcess(pgid=123)
-    proc_entries = {"456": ("S", 123)}
-    plugin.extra_tunnel_processes = {8080: process}
-    plugin.extra_tunnel_log_readers = {8080: {}}
-    plugin.extra_tunnel_urls = {8080: "https://example.test"}
-    plugin.extra_tunnel_start_times = {8080: 10}
+    proc_entries = {
+      "456": ("Z", 123),
+      "789": ("S", 123),
+    }
 
     with patch("extensions.business.container_apps.container_app_runner.os.name", "posix"), \
          patch("extensions.business.container_apps.container_app_runner.os.path.isdir", return_value=True), \
          patch("extensions.business.container_apps.container_app_runner.os.listdir", return_value=list(proc_entries)), \
          patch("extensions.business.container_apps.container_app_runner.os.killpg", return_value=None), \
          patch("builtins.open", _fake_proc_stat_open(proc_entries)):
-      self.assertFalse(plugin._stop_extra_tunnel(8080))
+      self.assertFalse(plugin._terminate_subprocess_tree(process, terminate_timeout=0, kill_timeout=0))
 
+    self.assertFalse(process.terminated)
+    self.assertFalse(process.killed)
+
+  def test_local_subprocess_fallback_keeps_stopped_or_traced_group_failed(self):
+    for state in ("T", "t"):
+      with self.subTest(state=state):
+        plugin, _, _ = make_lifecycle_runner()
+        process = _StoppedProcess(pgid=123)
+        proc_entries = {"456": (state, 123)}
+
+        with patch("extensions.business.container_apps.container_app_runner.os.name", "posix"), \
+             patch("extensions.business.container_apps.container_app_runner.os.path.isdir", return_value=True), \
+             patch("extensions.business.container_apps.container_app_runner.os.listdir", return_value=list(proc_entries)), \
+             patch("extensions.business.container_apps.container_app_runner.os.killpg", return_value=None), \
+             patch("builtins.open", _fake_proc_stat_open(proc_entries)):
+          self.assertFalse(plugin._terminate_subprocess_tree(process, terminate_timeout=0, kill_timeout=0))
+
+        self.assertFalse(process.terminated)
+        self.assertFalse(process.killed)
+
+  def test_local_subprocess_fallback_ignores_vanished_and_mismatched_members(self):
+    plugin, _, _ = make_lifecycle_runner()
+    process = _StoppedProcess(pgid=123)
+    proc_entries = {
+      "456": ("Z", 123),
+      "789": ("S", 999),
+    }
+
+    with patch("extensions.business.container_apps.container_app_runner.os.name", "posix"), \
+         patch("extensions.business.container_apps.container_app_runner.os.path.isdir", return_value=True), \
+         patch("extensions.business.container_apps.container_app_runner.os.listdir", return_value=["456", "789", "901"]), \
+         patch("extensions.business.container_apps.container_app_runner.os.killpg", return_value=None), \
+         patch("builtins.open", _fake_proc_stat_open(proc_entries)):
+      self.assertTrue(plugin._terminate_subprocess_tree(process, terminate_timeout=0, kill_timeout=0))
+
+    self.assertFalse(process.terminated)
+    self.assertFalse(process.killed)
+
+  def test_local_subprocess_fallback_keeps_group_conservative_without_proc_matches(self):
+    plugin, _, _ = make_lifecycle_runner()
+    process = _StoppedProcess(pgid=123)
+    proc_entries = {"456": ("S", 999)}
+
+    with patch("extensions.business.container_apps.container_app_runner.os.name", "posix"), \
+         patch("extensions.business.container_apps.container_app_runner.os.path.isdir", return_value=True), \
+         patch("extensions.business.container_apps.container_app_runner.os.listdir", return_value=list(proc_entries)), \
+         patch("extensions.business.container_apps.container_app_runner.os.killpg", return_value=None), \
+         patch("builtins.open", _fake_proc_stat_open(proc_entries)):
+      self.assertFalse(plugin._terminate_subprocess_tree(process, terminate_timeout=0, kill_timeout=0))
+
+    self.assertFalse(process.terminated)
+    self.assertFalse(process.killed)
+
+  def test_local_subprocess_fallback_skips_unreadable_proc_entries(self):
+    plugin, _, _ = make_lifecycle_runner()
+    process = _StoppedProcess(pgid=123)
+    proc_entries = {
+      "456": ("Z", 123),
+      "789": RuntimeError("broken stat"),
+    }
+
+    with patch("extensions.business.container_apps.container_app_runner.os.name", "posix"), \
+         patch("extensions.business.container_apps.container_app_runner.os.path.isdir", return_value=True), \
+         patch("extensions.business.container_apps.container_app_runner.os.listdir", return_value=list(proc_entries)), \
+         patch("extensions.business.container_apps.container_app_runner.os.killpg", return_value=None), \
+         patch("builtins.open", _fake_proc_stat_open(proc_entries)):
+      self.assertTrue(plugin._terminate_subprocess_tree(process, terminate_timeout=0, kill_timeout=0))
+
+    self.assertFalse(process.terminated)
+    self.assertFalse(process.killed)
+
+  def test_extra_tunnel_stopped_parent_with_live_descendant_is_preserved(self):
+    plugin, _, _ = make_lifecycle_runner()
+    process = _StoppedProcess(pgid=123)
+    plugin.extra_tunnel_processes = {8080: process}
+    plugin.extra_tunnel_log_readers = {8080: {}}
+    plugin.extra_tunnel_urls = {8080: "https://example.test"}
+    plugin.extra_tunnel_start_times = {8080: 10}
+    plugin._terminate_subprocess_tree = MagicMock(return_value=False)
+
+    self.assertFalse(plugin._stop_extra_tunnel(8080))
+
+    plugin._terminate_subprocess_tree.assert_called_once_with(
+      process,
+      label="Extra tunnel for port 8080",
+    )
     self.assertIn(8080, plugin.extra_tunnel_processes)
     self.assertIn(8080, plugin.extra_tunnel_log_readers)
     self.assertIn(8080, plugin.extra_tunnel_urls)


### PR DESCRIPTION
What changed:
- keep CAR tunnel-tree cleanup zombie-aware locally for mixed core deployments
- continue low-noise cleanup probes after retry exhaustion
- allow fixed-size volume cleanup after Docker removal while sidecars remain retryable
- preserve extra-tunnel handles when stopped parents still have live descendants

Why:
- prevent drs1-style Cloudflare tunnel cleanup failures from leaving container apps permanently stuck while preserving fail-closed restart behavior