### PR TITLE
feat: add debug FastAPI pause cycle

### DIFF
--- a/cmds/device_comms.py
+++ b/cmds/device_comms.py
@@ -44,6 +44,11 @@ _COMMS_ADMIN_PIPELINE = {
   "NETMON_API_PROBE": {},
 }
 
+if _env_flag("EE_ENABLE_DEBUG_FASTAPI_PAUSE_CYCLE"):
+  _COMMS_ADMIN_PIPELINE["DEBUG_FASTAPI_PAUSE_CYCLE"] = {
+    "PAUSE_SECONDS": _env_int("EE_DEBUG_FASTAPI_PAUSE_SECONDS", 5),
+  }
+
 if _env_flag("EE_ENABLE_LOCAL_ORACLE_SYNC"):
   # OracleSync is intentionally opt-in for the comms testbed. The default
   # NetMon/QoS tests must stay isolated from blockchain/R1FS behavior, while

--- a/docker-compose/debug-fastapi-pause-cycle.yaml
+++ b/docker-compose/debug-fastapi-pause-cycle.yaml
@@ -1,0 +1,11 @@
+services:
+  ratio1_comm_node_01:
+    environment:
+      EE_ENABLE_DEBUG_FASTAPI_PAUSE_CYCLE: "1"
+      EE_DEBUG_FASTAPI_PAUSE_SECONDS: "${EE_DEBUG_FASTAPI_PAUSE_SECONDS:-5}"
+    ports:
+      - "127.0.0.1:3201:3001"
+
+networks:
+  comms_local:
+    name: "${R1_PAUSE_E2E_NETWORK:-r1_pause_e2e}"

--- a/plugins/business/fastapi/debug_fastapi_pause_cycle.py
+++ b/plugins/business/fastapi/debug_fastapi_pause_cycle.py
@@ -1,0 +1,111 @@
+import os
+
+
+if os.environ.get("EE_ENABLE_DEBUG_FASTAPI_PAUSE_CYCLE", "").strip().lower() not in {"1", "true", "yes"}:
+  raise RuntimeError("DEBUG_FASTAPI_PAUSE_CYCLE is disabled outside its explicit debug testbed.")
+
+
+from naeural_core.business.default.web_app.fast_api_web_app import FastApiWebAppPlugin as BasePlugin
+
+
+__VER__ = "0.1.0"
+
+
+_CONFIG = {
+  **BasePlugin.CONFIG,
+
+  "PORT": 3001,
+  "ASSETS": None,
+  "TEMPLATE": "basic_server",
+  "TUNNEL_ENGINE": "cloudflare",
+  "TUNNEL_ENGINE_ENABLED": True,
+  "REQUESTS_PER_PAUSE": 10,
+  "PAUSE_SECONDS": 10 * 60,
+  "MAX_INCOMING_PER_LOOP": 1,
+  "PROCESS_DELAY": 0,
+  "LOG_REQUESTS": True,
+  "DEBUG_TIMINGS": False,
+  "PROFILE_LOG_PER_REQUEST": False,
+
+  "VALIDATION_RULES": {
+    **BasePlugin.CONFIG["VALIDATION_RULES"],
+  },
+}
+
+
+class DebugFastapiPauseCyclePlugin(BasePlugin):
+  """Debug FastAPI app that pauses after each configured request batch."""
+  CONFIG = _CONFIG
+
+  def on_init(self):
+    self.__requests_since_pause = 0
+    self.__pause_until = None
+    self.__pause_teardown_succeeded = True
+    super(DebugFastapiPauseCyclePlugin, self).on_init()
+    return
+
+  def on_response(self, method, response):
+    super(DebugFastapiPauseCyclePlugin, self).on_response(method, response)
+    self.__requests_since_pause += 1
+    if (
+      self.__pause_until is None and
+      self.__requests_since_pause >= self.cfg_requests_per_pause
+    ):
+      self.__pause_until = self.time() + self.cfg_pause_seconds
+    return
+
+  def should_pause(self):
+    return self.__pause_until is not None
+
+  def should_resume(self):
+    return self.__pause_until is None or self.time() >= self.__pause_until
+
+  def on_pause(self):
+    if not self._init_process_finalized:
+      return
+    self.__pause_teardown_succeeded = False
+    self._stop_request_monitor.set()
+    if self._request_monitor_thread is not None:
+      self._request_monitor_thread.join(timeout=1.0)
+    self._maybe_close_start_commands()
+    running_commands = [
+      idx for idx, process in enumerate(self.start_commands_processes)
+      if process is not None and process.poll() is None
+    ]
+    if running_commands:
+      raise RuntimeError(f"Failed to stop start commands {running_commands} while pausing")
+    if self._request_monitor_thread is not None and self._request_monitor_thread.is_alive():
+      raise RuntimeError("Failed to stop the FastAPI request monitor while pausing")
+
+    with self._incoming_lock:
+      self._incoming_requests.clear()
+    self.postponed_requests.clear()
+    while True:
+      try:
+        self._server_queue.get(False)
+      except Exception:
+        break
+    self._maybe_read_and_stop_all_log_readers()
+    self.reset_tunnel_engine()
+
+    nr_commands = len(self.get_start_commands())
+    self.start_commands_started = [False] * nr_commands
+    self.start_commands_finished = [False] * nr_commands
+    self.start_commands_processes = [None] * nr_commands
+    self.start_commands_start_time = [None] * nr_commands
+    self.__pause_teardown_succeeded = True
+    return
+
+  def on_resume(self):
+    if not self.__pause_teardown_succeeded:
+      raise RuntimeError("Cannot resume after an incomplete web app teardown")
+    self.__requests_since_pause = 0
+    self.__pause_until = None
+    self.failed = False
+    self._stop_request_monitor.clear()
+    self._start_request_monitor_thread()
+    return
+
+  @BasePlugin.endpoint(method="get", require_token=False)
+  def ping(self):
+    return {"message": "pong"}

--- a/tests/run_debug_fastapi_pause_cycle_e2e.sh
+++ b/tests/run_debug_fastapi_pause_cycle_e2e.sh
@@ -1,0 +1,44 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+EDGE_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+: "${NAEURAL_CORE_ROOT:?Set NAEURAL_CORE_ROOT to the naeural_core worktree under test}"
+: "${NAEURAL_CLIENT_ROOT:?Set NAEURAL_CLIENT_ROOT to an up-to-date naeural_client checkout}"
+
+for container in r1_comms_emqx ratio1_comm_node_01; do
+  if docker ps -a --format '{{.Names}}' | grep -qx "${container}"; then
+    echo "Container ${container} already exists; remove it before running this isolated testbed." >&2
+    exit 1
+  fi
+done
+
+context="$(mktemp -d "${TMPDIR:-/tmp}/r1-pause-e2e.XXXXXX")"
+project="r1_pause_e2e_${RANDOM}_$$"
+compose=(
+  docker compose -p "${project}"
+  -f docker-compose_comms.yaml
+  -f docker-compose/debug-fastapi-pause-cycle.yaml
+)
+
+cleanup() {
+  if [[ -d "${context}/edge_node" ]]; then
+    (cd "${context}/edge_node" && EDGE_NODE_COMMS_IMAGE=local_edge_node_pause_e2e "${compose[@]}" down -v --remove-orphans) || true
+  fi
+  rm -rf "${context}"
+}
+trap cleanup EXIT
+
+mkdir -p "${context}"/{edge_node,naeural_core,naeural_client}
+rsync -a --exclude=.git --exclude=__pycache__ --exclude='*.pyc' "${EDGE_ROOT}/" "${context}/edge_node/"
+rsync -a --exclude=.git --exclude=__pycache__ --exclude='*.pyc' "${NAEURAL_CORE_ROOT}/" "${context}/naeural_core/"
+git -C "${NAEURAL_CLIENT_ROOT}" fetch --prune origin
+git -C "${NAEURAL_CLIENT_ROOT}" archive origin/main | tar -x -C "${context}/naeural_client"
+
+cd "${context}/edge_node"
+export EDGE_NODE_COMMS_IMAGE=local_edge_node_pause_e2e
+export INSTALL_KUBO=0
+export R1_PAUSE_E2E_NETWORK="${project}_network"
+"${compose[@]}" config --quiet
+"${compose[@]}" build ratio1_comm_node_01
+"${compose[@]}" up -d --no-build emqx ratio1_comm_node_01
+python3 tests/validate_debug_fastapi_pause_cycle.py --pause-seconds "${EE_DEBUG_FASTAPI_PAUSE_SECONDS:-5}"

--- a/tests/test_comms_testbed_config.py
+++ b/tests/test_comms_testbed_config.py
@@ -27,6 +27,8 @@ class TestCommunicationComposeTestbed(unittest.TestCase):
     self.assertNotIn("naeural_test", compose_text)
     self.assertNotIn("naeural/ctrl", compose_text)
     self.assertIn("starts an inner Docker daemon", compose_text)
+    self.assertNotIn("EE_ENABLE_DEBUG_FASTAPI_PAUSE_CYCLE", compose_text)
+    self.assertNotIn('"127.0.0.1:3201:3001"', compose_text)
     self.assertIn("privileged: true", compose_text)
     self.assertNotIn("EE_EVM_NET: testnet", compose_text)
     self.assertNotIn("EE_EVM_NET: mainnet", compose_text)
@@ -254,7 +256,18 @@ class TestCommunicationComposeTestbed(unittest.TestCase):
     self.assertIn("main(additional_packages=[])", comms_entrypoint)
     self.assertIn("local LLM serving", comms_entrypoint)
     self.assertIn("ct.ADMIN_PIPELINE = _COMMS_ADMIN_PIPELINE", comms_entrypoint)
+    self.assertIn("EE_ENABLE_DEBUG_FASTAPI_PAUSE_CYCLE", comms_entrypoint)
+    self.assertIn('"DEBUG_FASTAPI_PAUSE_CYCLE"', comms_entrypoint)
     self.assertIn("OracleSync", comms_entrypoint)
+
+  def test_debug_fastapi_pause_cycle_is_an_explicit_compose_override(self):
+    override = (
+      REPO_ROOT / "docker-compose" / "debug-fastapi-pause-cycle.yaml"
+    ).read_text()
+
+    self.assertIn('EE_ENABLE_DEBUG_FASTAPI_PAUSE_CYCLE: "1"', override)
+    self.assertIn('"127.0.0.1:3201:3001"', override)
+    self.assertIn("R1_PAUSE_E2E_NETWORK", override)
 
 
 if __name__ == "__main__":

--- a/tests/test_debug_fastapi_pause_cycle.py
+++ b/tests/test_debug_fastapi_pause_cycle.py
@@ -1,0 +1,199 @@
+from collections import deque
+import os
+import queue
+import threading
+import unittest
+from pathlib import Path
+from unittest.mock import patch
+
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+class _FakeProcess:
+  def __init__(self):
+    self.running = True
+
+  def poll(self):
+    return None if self.running else 0
+
+
+class _FakeBasePlugin:
+  CONFIG = {"VALIDATION_RULES": {}}
+
+  @staticmethod
+  def endpoint(method="get", require_token=False):  # pylint: disable=unused-argument
+    def decorator(func):
+      return func
+
+    return decorator
+
+  def __init__(self):
+    self.cfg_requests_per_pause = 10
+    self.cfg_pause_seconds = 600
+    self._init_process_finalized = True
+    self._now = 100.0
+    self.base_responses = []
+    self.lifecycle_events = []
+    self.start_commands_started = [True, True]
+    self.start_commands_finished = [True, True]
+    self.start_commands_processes = [_FakeProcess(), _FakeProcess()]
+    self.start_commands_start_time = [90.0, 95.0]
+    self.failed = False
+    self._stop_request_monitor = threading.Event()
+    self._request_monitor_thread = None
+    self._incoming_lock = threading.Lock()
+    self._incoming_requests = deque()
+    self.postponed_requests = deque()
+    self._server_queue = queue.Queue()
+
+  def on_init(self):
+    self.lifecycle_events.append("init")
+
+  def on_response(self, method, response):
+    self.base_responses.append((method, response))
+
+  def time(self):
+    return self._now
+
+  def get_start_commands(self):
+    return ["uvicorn", "cloudflared"]
+
+  def _maybe_close_start_commands(self):
+    self.lifecycle_events.append("stop_commands")
+    for process in self.start_commands_processes:
+      if process is not None:
+        process.running = False
+
+  def _maybe_read_and_stop_all_log_readers(self):
+    self.lifecycle_events.append("stop_log_readers")
+
+  def reset_tunnel_engine(self):
+    self.lifecycle_events.append("reset_tunnel")
+
+  def _start_request_monitor_thread(self):
+    self.lifecycle_events.append("start_monitor")
+
+
+def _load_plugin_class(enabled=True):
+  source_path = ROOT / "plugins" / "business" / "fastapi" / "debug_fastapi_pause_cycle.py"
+  source = source_path.read_text(encoding="utf-8")
+  source = source.replace(
+    "from naeural_core.business.default.web_app.fast_api_web_app import FastApiWebAppPlugin as BasePlugin\n",
+    "",
+  )
+  namespace = {"BasePlugin": _FakeBasePlugin, "__name__": "loaded_debug_fastapi_pause_cycle"}
+  value = "1" if enabled else ""
+  with patch.dict(os.environ, {"EE_ENABLE_DEBUG_FASTAPI_PAUSE_CYCLE": value}):
+    exec(compile(source, str(source_path), "exec"), namespace)  # noqa: S102
+  return namespace["DebugFastapiPauseCyclePlugin"]
+
+
+class DebugFastapiPauseCycleTests(unittest.TestCase):
+  @classmethod
+  def setUpClass(cls):
+    cls.plugin_class = _load_plugin_class()
+
+  def _make_plugin(self):
+    plugin = self.plugin_class()
+    plugin.on_init()
+    return plugin
+
+  def test_defaults_pause_for_ten_minutes_after_ten_requests(self):
+    self.assertEqual(self.plugin_class.CONFIG["REQUESTS_PER_PAUSE"], 10)
+    self.assertEqual(self.plugin_class.CONFIG["PAUSE_SECONDS"], 600)
+    self.assertTrue(self.plugin_class.CONFIG["TUNNEL_ENGINE_ENABLED"])
+    self.assertEqual(self.plugin_class.CONFIG["TUNNEL_ENGINE"], "cloudflare")
+    self.assertEqual(self.plugin_class.CONFIG["MAX_INCOMING_PER_LOOP"], 1)
+
+  def test_plugin_requires_explicit_debug_opt_in(self):
+    with self.assertRaisesRegex(RuntimeError, "disabled outside"):
+      _load_plugin_class(enabled=False)
+
+  def test_tenth_response_starts_pause_and_lifecycle_resets_processes(self):
+    plugin = self._make_plugin()
+
+    for request_nr in range(1, 10):
+      plugin.on_response("ping", {"request_nr": request_nr})
+      self.assertFalse(plugin.should_pause())
+
+    plugin.on_response("ping", {"request_nr": 10})
+    self.assertTrue(plugin.should_pause())
+    self.assertEqual(len(plugin.base_responses), 10)
+
+    plugin.on_pause()
+    self.assertEqual(
+      plugin.lifecycle_events,
+      ["init", "stop_commands", "stop_log_readers", "reset_tunnel"],
+    )
+    self.assertEqual(plugin.start_commands_started, [False, False])
+    self.assertEqual(plugin.start_commands_finished, [False, False])
+    self.assertEqual(plugin.start_commands_processes, [None, None])
+    self.assertEqual(plugin.start_commands_start_time, [None, None])
+
+    plugin._now = 699.9
+    self.assertFalse(plugin.should_resume())
+    plugin._now = 700.0
+    self.assertTrue(plugin.should_resume())
+
+  def test_resume_resets_counter_for_the_next_ten_request_cycle(self):
+    plugin = self._make_plugin()
+    for request_nr in range(10):
+      plugin.on_response("ping", {"request_nr": request_nr})
+
+    plugin.on_pause()
+    plugin._now = 700.0
+    plugin.failed = True
+    plugin.on_resume()
+
+    self.assertFalse(plugin.should_pause())
+    self.assertFalse(plugin.failed)
+    self.assertFalse(plugin._stop_request_monitor.is_set())
+    self.assertEqual(plugin.lifecycle_events[-1], "start_monitor")
+    for request_nr in range(9):
+      plugin.on_response("ping", {"request_nr": request_nr})
+    self.assertFalse(plugin.should_pause())
+    plugin.on_response("ping", {"request_nr": 10})
+    self.assertTrue(plugin.should_pause())
+
+  def test_operator_pause_without_request_deadline_can_resume(self):
+    plugin = self._make_plugin()
+
+    self.assertTrue(plugin.should_resume())
+
+  def test_initial_disabled_pause_is_safe_before_web_app_initialization(self):
+    plugin = self._make_plugin()
+    plugin._init_process_finalized = False
+
+    plugin.on_pause()
+
+    self.assertEqual(plugin.lifecycle_events, ["init"])
+
+  def test_failed_process_teardown_blocks_resume_without_discarding_handles(self):
+    plugin = self._make_plugin()
+    processes = list(plugin.start_commands_processes)
+    plugin._maybe_close_start_commands = lambda: None
+
+    with self.assertRaisesRegex(RuntimeError, "Failed to stop"):
+      plugin.on_pause()
+
+    self.assertEqual(plugin.start_commands_processes, processes)
+    with self.assertRaisesRegex(RuntimeError, "incomplete web app teardown"):
+      plugin.on_resume()
+
+  def test_pause_discards_requests_owned_by_the_stopped_uvicorn(self):
+    plugin = self._make_plugin()
+    plugin._incoming_requests.extend(["incoming-1", "incoming-2"])
+    plugin.postponed_requests.append("postponed")
+    plugin._server_queue.put("server")
+
+    plugin.on_pause()
+
+    self.assertTrue(plugin._stop_request_monitor.is_set())
+    self.assertEqual(list(plugin._incoming_requests), [])
+    self.assertEqual(list(plugin.postponed_requests), [])
+    self.assertTrue(plugin._server_queue.empty())
+
+
+if __name__ == "__main__":
+  unittest.main()

--- a/tests/validate_debug_fastapi_pause_cycle.py
+++ b/tests/validate_debug_fastapi_pause_cycle.py
@@ -1,0 +1,140 @@
+#!/usr/bin/env python3
+import argparse
+from concurrent.futures import ThreadPoolExecutor
+import json
+import subprocess
+import threading
+import time
+from urllib.error import URLError
+from urllib.request import urlopen
+
+
+def request_json(url, timeout=2):
+  with urlopen(url, timeout=timeout) as response:
+    return json.load(response)
+
+
+def wait_for_http(url, available, timeout):
+  deadline = time.monotonic() + timeout
+  while time.monotonic() < deadline:
+    try:
+      request_json(url)
+      current = True
+    except (OSError, URLError, ValueError):
+      current = False
+    if current == available:
+      return time.monotonic()
+    time.sleep(0.2)
+  state = "available" if available else "unavailable"
+  raise RuntimeError(f"{url} did not become {state} within {timeout}s")
+
+
+def process_is_running(container, pattern):
+  result = subprocess.run(
+    ["docker", "exec", container, "pgrep", "-af", pattern],
+    check=False,
+    capture_output=True,
+    text=True,
+  )
+  return result.returncode == 0
+
+
+def wait_for_process(container, pattern, running, timeout):
+  deadline = time.monotonic() + timeout
+  while time.monotonic() < deadline:
+    if process_is_running(container, pattern) == running:
+      return
+    time.sleep(0.2)
+  state = "running" if running else "stopped"
+  raise RuntimeError(f"process {pattern!r} did not become {state} within {timeout}s")
+
+
+def tunnel_ready_count(container):
+  result = subprocess.run(
+    ["docker", "logs", container],
+    check=True,
+    capture_output=True,
+    text=True,
+  )
+  logs = result.stdout + result.stderr
+  return logs.count("Cloudflare tunnel started successfully on:")
+
+
+def wait_for_tunnel_ready_count(container, minimum, timeout):
+  deadline = time.monotonic() + timeout
+  while time.monotonic() < deadline:
+    count = tunnel_ready_count(container)
+    if count >= minimum:
+      time.sleep(1)
+      if process_is_running(container, "[c]loudflared.*127.0.0.1:3001"):
+        return count
+    time.sleep(0.5)
+  raise RuntimeError(f"cloudflared did not reach readiness count {minimum} within {timeout}s")
+
+
+def validate_pause_transition(base_url, container, pause_seconds, tunnel_count):
+  health_url = f"{base_url}/openapi.json"
+  unavailable_at = wait_for_http(health_url, available=False, timeout=10)
+  wait_for_process(container, "[u]vicorn.*--port 3001", running=False, timeout=5)
+  wait_for_process(container, "[c]loudflared.*127.0.0.1:3001", running=False, timeout=5)
+
+  resume_timeout = pause_seconds + 20
+  available_at = wait_for_http(health_url, available=True, timeout=resume_timeout)
+  minimum_downtime = max(0, pause_seconds - 1)
+  if available_at - unavailable_at < minimum_downtime:
+    raise RuntimeError(
+      f"pause lasted {available_at - unavailable_at:.2f}s, expected at least {minimum_downtime:.2f}s"
+    )
+  wait_for_process(container, "[u]vicorn.*--port 3001", running=True, timeout=10)
+  wait_for_process(container, "[c]loudflared.*127.0.0.1:3001", running=True, timeout=10)
+  return wait_for_tunnel_ready_count(container, tunnel_count + 1, timeout=30)
+
+
+def validate_sequential_cycle(base_url, container, pause_seconds, tunnel_count):
+  ping_url = f"{base_url}/ping"
+  for request_nr in range(1, 11):
+    response = request_json(ping_url)
+    if response.get("result", {}).get("message") != "pong":
+      raise RuntimeError(f"request {request_nr} returned an unexpected response: {response}")
+  return validate_pause_transition(base_url, container, pause_seconds, tunnel_count)
+
+
+def validate_concurrent_cycle(base_url, container, pause_seconds, tunnel_count):
+  ping_url = f"{base_url}/ping"
+  barrier = threading.Barrier(20)
+
+  def send_request():
+    barrier.wait()
+    try:
+      response = request_json(ping_url, timeout=10)
+      return response.get("result", {}).get("message") == "pong"
+    except Exception:
+      return False
+
+  with ThreadPoolExecutor(max_workers=20) as executor:
+    successes = sum(executor.map(lambda _request_nr: send_request(), range(20)))
+  if successes != 10:
+    raise RuntimeError(f"concurrent boundary completed {successes} requests instead of exactly 10")
+  return validate_pause_transition(base_url, container, pause_seconds, tunnel_count)
+
+
+def main():
+  parser = argparse.ArgumentParser()
+  parser.add_argument("--base-url", default="http://127.0.0.1:3201")
+  parser.add_argument("--container", default="ratio1_comm_node_01")
+  parser.add_argument("--pause-seconds", type=float, default=5)
+  args = parser.parse_args()
+
+  wait_for_http(f"{args.base_url}/openapi.json", available=True, timeout=120)
+  wait_for_process(args.container, "[u]vicorn.*--port 3001", running=True, timeout=10)
+  wait_for_process(args.container, "[c]loudflared.*127.0.0.1:3001", running=True, timeout=30)
+  tunnel_count = wait_for_tunnel_ready_count(args.container, minimum=1, timeout=30)
+  tunnel_count = validate_concurrent_cycle(
+    args.base_url, args.container, args.pause_seconds, tunnel_count
+  )
+  validate_sequential_cycle(args.base_url, args.container, args.pause_seconds, tunnel_count)
+  print("Validated concurrent and sequential 10-request cycles with process and tunnel restarts.")
+
+
+if __name__ == "__main__":
+  main()


### PR DESCRIPTION
## What changed
- Added an explicitly opt-in `FastApiWebAppPlugin` descendant that pauses for 600 seconds after every 10 completed endpoint requests.
- Limited processing to one incoming request per executor turn so the pause gate is checked at the exact boundary.
- On pause, stops the request monitor, uvicorn, and Cloudflare, verifies teardown, and discards requests owned by the stopped uvicorn. On resume, restarts request monitoring and lets the inherited web-app loop restart uvicorn and the tunnel.
- Added a debug-only Compose override, exact-worktree staging runner, unit coverage, and a process/tunnel-aware validator. The normal comms stack reserves no debug port and does not load the plugin.

## Why
This is the first real resource-owning use case for the generic pause hooks introduced by [Ratio1/naeural_core#215](https://github.com/Ratio1/naeural_core/pull/215).

## Validation
- `python3 tests/test_debug_fastapi_pause_cycle.py` (8 passed)
- `python3 tests/test_comms_testbed_config.py` (18 passed)
- Python compilation, `bash -n`, Compose rendering, and `git diff --check`
- `tests/run_debug_fastapi_pause_cycle_e2e.sh` against the exact `edge_node` and `naeural_core` worktrees
- Live E2E passed a simultaneous 20-request burst with exactly 10 successful responses before pause, then a clean sequential 10-request cycle
- Both cycles verified minimum pause duration, uvicorn and cloudflared absence during pause, process restart, and a fresh healthy Cloudflare tunnel after resume
- The runner used unique Compose project volumes/network and removed all containers, volumes, network, and staging data

## Dependency
Merge [Ratio1/naeural_core#215](https://github.com/Ratio1/naeural_core/pull/215) before running or merging this use case.