### PR TITLE
feat: route LLM requests by model

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -202,3 +202,6 @@ prompt.md
 
 # RedMesh LLM probe benchmark artifacts
 extensions/business/cybersec/red_mesh/test_results/
+
+# Local SDK state created by the isolated per-node LLM testbed
+.per-node-llm-e2e-sdk-cache/

--- a/docker-compose/deeploy-testbed/config_startup_deeploy_testbed.json
+++ b/docker-compose/deeploy-testbed/config_startup_deeploy_testbed.json
@@ -1,5 +1,5 @@
 {
-  "EE_ID": "deeploy_node",
+  "EE_ID": "$EE_ID",
   "SECURED": false,
   "IO_FORMATTER": "",
   "MAIN_LOOP_RESOLUTION": 10,

--- a/docker-compose/per-node-llm-e2e.yaml
+++ b/docker-compose/per-node-llm-e2e.yaml
@@ -1,0 +1,94 @@
+name: per-node-llm-e2e
+
+x-edge-env: &edge-env
+  AINODE_ENV: per-node-llm-e2e
+  EE_CONFIG: /edge_node/docker-compose/deeploy-testbed/config_startup_deeploy_testbed.json
+  EE_DEVICE: cpu
+  EE_ETH_ENABLED: "false"
+  EE_EVM_NET: devnet
+  EE_DAUTH_URL: N/A
+  EE_MQTT_HOST: per_node_llm_mqtt
+  EE_MQTT_PORT: "1883"
+  EE_MQTT_USER: ""
+  EE_MQTT: ""
+  EE_MQTT_SUBTOPIC: address
+  EE_MQTT_SECURED: "false"
+  EE_SECURED: "0"
+  EE_MINIO_ENDPOINT: ""
+  EE_MINIO_ACCESS_KEY: ""
+  EE_MINIO_SECRET_KEY: ""
+  EE_MINIO_SECURE: "false"
+  EE_MINIO_MODEL_BUCKET: ""
+  EE_MINIO_UPLOAD_BUCKET: ""
+  EE_GITVER: ""
+  EE_NGROK_AUTH_TOKEN: ""
+  EE_NGROK_EDGE_LABEL: ""
+  EE_NGROK_EDGE_LABEL_DEEPLOY_MANAGER: ""
+  EE_CLOUDFLARE_TOKEN_DEEPLOY_MANAGER: ""
+  EE_TUNNEL_ENGINE: none
+  PYTHONPATH: /opt/naeural_core:/edge_node
+
+x-edge-node: &edge-node
+  image: per-node-llm-e2e-edge:latest
+  build:
+    context: ..
+    dockerfile: docker-compose/per-node-llm-e2e/Dockerfile
+  privileged: true
+  restart: "no"
+  command: ["python3", "/edge_node/docker-compose/deeploy-testbed/device_no_extra_packages.py"]
+  depends_on:
+    per_node_llm_mqtt:
+      condition: service_healthy
+  environment: *edge-env
+  networks:
+    - per_node_llm_net
+
+services:
+  per_node_llm_mqtt:
+    image: eclipse-mosquitto:2
+    restart: "no"
+    ports:
+      - "127.0.0.1:18884:1883"
+    volumes:
+      - ./deeploy-testbed/mosquitto.conf:/mosquitto/config/mosquitto.conf:ro
+    healthcheck:
+      test: ["CMD-SHELL", "mosquitto_pub -h localhost -p 1883 -t per_node_llm/health -m ok >/dev/null 2>&1"]
+      interval: 2s
+      timeout: 2s
+      retries: 20
+    networks:
+      - per_node_llm_net
+
+  per_node_llm_node_1:
+    <<: *edge-node
+    environment:
+      <<: *edge-env
+      EE_ID: per_node_llm_node_1
+      EE_SUPERVISOR: "false"
+    ports:
+      - "127.0.0.1:18101:18080"
+    volumes:
+      - per_node_llm_node_1_cache:/edge_node/_local_cache
+      - ../../naeural_core:/opt/naeural_core:ro
+      - ${PER_NODE_LLM_MODEL_A:?set PER_NODE_LLM_MODEL_A to an absolute GGUF path}:/models/model-a.gguf:ro
+
+  per_node_llm_node_2:
+    <<: *edge-node
+    environment:
+      <<: *edge-env
+      EE_ID: per_node_llm_node_2
+      EE_SUPERVISOR: "false"
+    ports:
+      - "127.0.0.1:18102:18080"
+    volumes:
+      - per_node_llm_node_2_cache:/edge_node/_local_cache
+      - ../../naeural_core:/opt/naeural_core:ro
+      - ${PER_NODE_LLM_MODEL_B:?set PER_NODE_LLM_MODEL_B to an absolute GGUF path}:/models/model-b.gguf:ro
+
+networks:
+  per_node_llm_net:
+    internal: false
+
+volumes:
+  per_node_llm_node_1_cache:
+  per_node_llm_node_2_cache:

--- a/docker-compose/per-node-llm-e2e/Dockerfile
+++ b/docker-compose/per-node-llm-e2e/Dockerfile
@@ -1,0 +1,32 @@
+ARG BASE_IMAGE=ratio1/base_edge_node_amd64_cpu:latest
+FROM ${BASE_IMAGE}
+
+ARG KUBO_VERSION=v0.35.0
+RUN set -eux; \
+    curl -fsSLo kubo.tar.gz https://dist.ipfs.tech/kubo/${KUBO_VERSION}/kubo_${KUBO_VERSION}_linux-amd64.tar.gz; \
+    tar -xzf kubo.tar.gz; \
+    cd kubo && bash install.sh; \
+    cd / && rm -rf kubo kubo.tar.gz
+
+WORKDIR /edge_node
+
+COPY requirements.txt .
+RUN uv pip install --system --no-cache -r requirements.txt
+RUN uv pip install --system --no-cache --no-deps naeural-core
+RUN CMAKE_ARGS="-DGGML_CUDA=OFF" uv pip install --system --no-cache llama-cpp-python
+
+COPY ./cmds /usr/local/bin/
+RUN chmod +x /usr/local/bin/*
+
+COPY . .
+RUN rm -rf /edge_node/cmds
+
+ENV AINODE_DOCKER=Yes
+ENV AINODE_DOCKER_SOURCE=feat/per-node-biz-config
+ENV EE_DD=0
+ENV EE_CONFIG=.config_startup.json
+ENV EE_ETH_ENABLED=false
+ENV EE_EVM_NET=devnet
+ENV EE_DEVICE=cpu
+
+CMD ["python3", "device.py"]

--- a/docker-compose/per-node-llm-e2e/README.md
+++ b/docker-compose/per-node-llm-e2e/README.md
@@ -1,0 +1,39 @@
+# Per-Node LLM Deeploy E2E
+
+This testbed starts exactly two edge nodes and a private Mosquitto broker in a
+dedicated Compose network. Each node has an independent cache volume and mounts
+only its assigned GGUF model.
+
+The validator sends the same Deeploy-marked `LLM_INFERENCE_API` pipeline to both
+nodes. `PER_NODE_CONFIG.byNode` selects a different `AI_ENGINE`, model path, and
+public model alias before serving startup. It then checks local and cross-node
+model-aware requests through the real HTTP API and ChainStore balancing path.
+
+Run from the `edge_node` worktree root:
+
+```bash
+export PER_NODE_LLM_MODEL_A=/absolute/path/to/llama-3.2-1b-instruct-q8_0.gguf
+export PER_NODE_LLM_MODEL_B=/absolute/path/to/Qwen3.5-0.8B-Q8_0.gguf
+docker compose -f docker-compose/per-node-llm-e2e.yaml up -d --build
+PYTHONDONTWRITEBYTECODE=1 \
+PYTHONPATH=../naeural_core:. \
+python3 \
+  docker-compose/per-node-llm-e2e/validate_per_node_llm.py
+docker compose -f docker-compose/per-node-llm-e2e.yaml down -v
+```
+
+`PER_NODE_LLM_MODEL_A` and `PER_NODE_LLM_MODEL_B` are required absolute paths.
+The validated pairing is Llama 3.2 1B Instruct Q8_0 from `hugging-quants` and
+Qwen3.5 0.8B Q8_0 from `unsloth`; equivalent local GGUF artifacts can be used
+when recreating the testbed elsewhere.
+
+Expected scenarios:
+
+1. Node 1 serves `llama-1b` locally.
+2. Node 2 serves `qwen-0.8b` locally.
+3. A `qwen-0.8b` request sent to node 1 executes on node 2.
+4. A `llama-1b` request sent to node 2 executes on node 1.
+
+The validator writes a sanitized JSON result under
+`docker-compose/per-node-llm-e2e/results/`. Compose teardown removes all node
+state and the private broker network.

--- a/docker-compose/per-node-llm-e2e/results/.gitignore
+++ b/docker-compose/per-node-llm-e2e/results/.gitignore
@@ -1,0 +1,2 @@
+*
+!.gitignore

--- a/docker-compose/per-node-llm-e2e/validate_per_node_llm.py
+++ b/docker-compose/per-node-llm-e2e/validate_per_node_llm.py
@@ -1,0 +1,269 @@
+#!/usr/bin/env python3
+import json
+import os
+import shutil
+import subprocess
+import sys
+import tempfile
+import time
+import urllib.error
+import urllib.request
+from datetime import datetime, timezone
+from pathlib import Path
+
+from ratio1 import Session
+
+from naeural_core import constants as ct
+from extensions.business.deeploy.deeploy_const import DEEPLOY_KEYS, JOB_APP_TYPES
+
+
+CONTAINERS = ("per-node-llm-e2e-per_node_llm_node_1-1", "per-node-llm-e2e-per_node_llm_node_2-1")
+API_URLS = ("http://127.0.0.1:18101", "http://127.0.0.1:18102")
+MODEL_ALIASES = ("llama-1b", "qwen-0.8b")
+APP_ID = "per-node-llm-e2e-app"
+BROKER_HOST = os.environ.get("PER_NODE_LLM_MQTT_HOST", "127.0.0.1")
+BROKER_PORT = int(os.environ.get("PER_NODE_LLM_MQTT_PORT", "18884"))
+POLL_TIMEOUT = int(os.environ.get("PER_NODE_LLM_TIMEOUT", "900"))
+ROOT_TOPIC = "deeploy_testbed"
+
+
+def run(cmd, *, input_text=None, check=True):
+  result = subprocess.run(
+    cmd,
+    input=input_text,
+    text=True,
+    stdout=subprocess.PIPE,
+    stderr=subprocess.PIPE,
+    check=False,
+  )
+  if check and result.returncode != 0:
+    raise RuntimeError(
+      "Command failed: {}\nstdout:\n{}\nstderr:\n{}".format(
+        " ".join(cmd), result.stdout, result.stderr
+      )
+    )
+  return result
+
+
+def docker_exec(container, *args, input_text=None, check=True):
+  return run(["docker", "exec", "-i", container, *args], input_text=input_text, check=check)
+
+
+def wait_for_node_info(container):
+  deadline = time.time() + POLL_TIMEOUT
+  last_error = None
+  while time.time() < deadline:
+    result = docker_exec(container, "get_node_info", check=False)
+    if result.returncode == 0:
+      try:
+        info = json.loads(result.stdout)
+        if info.get("address"):
+          return info
+      except json.JSONDecodeError as exc:
+        last_error = exc
+    else:
+      last_error = result.stderr.strip() or result.stdout.strip()
+    time.sleep(2)
+  raise TimeoutError(f"Timed out waiting for node info from {container}: {last_error}")
+
+
+def update_allowed(container, entries):
+  input_text = "".join(f"{address} {alias}\n" for address, alias in entries)
+  docker_exec(container, "update_allowed_batch", input_text=input_text)
+
+
+def wait_for_stream(container):
+  path = f"/edge_node/_local_cache/_data/box_configuration/streams/{APP_ID}.json"
+  deadline = time.time() + POLL_TIMEOUT
+  while time.time() < deadline:
+    if docker_exec(container, "test", "-f", path, check=False).returncode == 0:
+      return
+    time.sleep(2)
+  raise TimeoutError(f"Timed out waiting for {APP_ID} on {container}")
+
+
+def request_json(url, method="GET", payload=None, timeout=30):
+  body = None if payload is None else json.dumps(payload).encode("utf-8")
+  request = urllib.request.Request(
+    url,
+    data=body,
+    method=method,
+    headers={"Content-Type": "application/json"},
+  )
+  with urllib.request.urlopen(request, timeout=timeout) as response:
+    return json.loads(response.read().decode("utf-8"))
+
+
+def wait_for_api(base_url):
+  deadline = time.time() + POLL_TIMEOUT
+  last_error = None
+  while time.time() < deadline:
+    try:
+      result = request_json(f"{base_url}/health", timeout=5)
+      status = result.get("status") or result.get("result", {}).get("status")
+      if status:
+        return result
+    except (OSError, ValueError, urllib.error.HTTPError) as exc:
+      last_error = exc
+    time.sleep(3)
+  raise TimeoutError(f"Timed out waiting for LLM API {base_url}: {last_error}")
+
+
+def make_pipeline_config(node_addresses):
+  now = time.time()
+  base_instance = {
+    "INSTANCE_ID": "llm-api",
+    "AI_ENGINE": "llama_cpp_small",
+    "STARTUP_AI_ENGINE_PARAMS": {
+      "MODEL_PATH": "/models/model-a.gguf",
+      "MODEL_N_CTX": 1024,
+      "N_THREADS": 2,
+      "N_GPU_LAYERS": 0,
+    },
+    "SERVED_MODELS": [MODEL_ALIASES[0]],
+    "PORT": 18080,
+    "TUNNEL_ENGINE_ENABLED": False,
+    "REQUEST_TIMEOUT": 600,
+    "REQUEST_BALANCING_ENABLED": True,
+    "REQUEST_BALANCING_GROUP": "per-node-llm-e2e",
+    "REQUEST_BALANCING_CAPACITY": 1,
+    "REQUEST_BALANCING_ANNOUNCE_PERIOD": 2,
+    "REQUEST_BALANCING_CAPACITY_REFRESH_PERIOD": 5,
+    "REQUEST_BALANCING_CAPACITY_REFRESH_JITTER_SECONDS": 0,
+    "REQUEST_BALANCING_PEER_STALE_SECONDS": 30,
+    "REQUEST_BALANCING_MAILBOX_POLL_PERIOD": 0.25,
+    "CHAINSTORE_PEERS": list(node_addresses),
+    "PER_NODE_TARGET_NODES": list(node_addresses),
+    "PER_NODE_CONFIG": {
+      "byNode": {
+        node_addresses[1]: {
+          "AI_ENGINE": "llama_cpp_medium",
+          "STARTUP_AI_ENGINE_PARAMS": {
+            "MODEL_PATH": "/models/model-b.gguf",
+            "MODEL_N_CTX": 1024,
+            "N_THREADS": 2,
+            "N_GPU_LAYERS": 0,
+          },
+          "SERVED_MODELS": [MODEL_ALIASES[1]],
+        },
+      },
+    },
+  }
+  return {
+    ct.CONFIG_STREAM.NAME: APP_ID,
+    ct.CONFIG_STREAM.TYPE: "Loopback",
+    ct.CONFIG_STREAM.LIVE_FEED: True,
+    "CAP_RESOLUTION": 10,
+    "URL": None,
+    "IS_DEEPLOYED": True,
+    "DEEPLOY_SPECS": {
+      DEEPLOY_KEYS.JOB_ID: 250805,
+      DEEPLOY_KEYS.JOB_APP_TYPE: JOB_APP_TYPES.NATIVE,
+      DEEPLOY_KEYS.NR_TARGET_NODES: len(node_addresses),
+      DEEPLOY_KEYS.CURRENT_TARGET_NODES: list(node_addresses),
+      DEEPLOY_KEYS.DATE_CREATED: now,
+      DEEPLOY_KEYS.DATE_UPDATED: now,
+      DEEPLOY_KEYS.JOB_TAGS: ["per-node-config", "model-routing", "local-e2e"],
+      DEEPLOY_KEYS.SPARE_NODES: [],
+      DEEPLOY_KEYS.ALLOW_REPLICATION_IN_THE_WILD: False,
+    },
+    ct.CONFIG_STREAM.PLUGINS: [{
+      ct.CONFIG_PLUGIN.K_SIGNATURE: "LLM_INFERENCE_API",
+      ct.CONFIG_PLUGIN.K_INSTANCES: [base_instance],
+    }],
+  }
+
+
+def predict(base_url, model):
+  started = time.time()
+  envelope = request_json(
+    f"{base_url}/predict",
+    method="POST",
+    timeout=POLL_TIMEOUT,
+    payload={
+      "model": model,
+      "messages": [{"role": "user", "content": "Reply with one short greeting."}],
+      "temperature": 0.0,
+      "max_tokens": 16,
+    },
+  )
+  response = envelope.get("result", envelope)
+  return {"elapsed_seconds": time.time() - started, "response": response}
+
+
+def main():
+  node_infos = {container: wait_for_node_info(container) for container in CONTAINERS}
+  node_addresses = [node_infos[container]["address"] for container in CONTAINERS]
+
+  cache_dir = Path(tempfile.mkdtemp(prefix="per-node-llm-e2e-sdk-"))
+  session = Session(
+    host=BROKER_HOST,
+    port=BROKER_PORT,
+    user="per_node_llm",
+    pwd="per_node_llm",
+    secured=False,
+    encrypt_comms=False,
+    root_topic=ROOT_TOPIC,
+    name="per-node-llm-e2e",
+    auto_configuration=False,
+    run_dauth=False,
+    use_home_folder=False,
+    local_cache_base_folder=str(cache_dir),
+    local_cache_app_folder="_local_cache",
+    debug=0,
+    verbosity=0,
+    silent=True,
+    show_commands=False,
+    eth_enabled=False,
+  )
+
+  try:
+    for idx, container in enumerate(CONTAINERS):
+      update_allowed(container, [
+        (session.bc_engine.address, "per_node_e2e"),
+        (node_addresses[1 - idx], f"peer_{1 - idx}"),
+      ])
+
+    pipeline = make_pipeline_config(node_addresses)
+    for node_address in node_addresses:
+      session._send_command_create_pipeline(node_address, pipeline, show_command=False)
+    for container in CONTAINERS:
+      wait_for_stream(container)
+    health = [wait_for_api(url) for url in API_URLS]
+
+    cases = [
+      ("node1-local-model-a", API_URLS[0], MODEL_ALIASES[0], node_addresses[0]),
+      ("node2-local-model-b", API_URLS[1], MODEL_ALIASES[1], node_addresses[1]),
+      ("node1-routes-model-b", API_URLS[0], MODEL_ALIASES[1], node_addresses[1]),
+      ("node2-routes-model-a", API_URLS[1], MODEL_ALIASES[0], node_addresses[0]),
+    ]
+    results = []
+    for name, url, model, expected_executor in cases:
+      result = predict(url, model)
+      executor = result["response"].get("EXECUTOR_NODE_ADDR")
+      if executor != expected_executor:
+        raise AssertionError(
+          f"{name} expected executor {expected_executor}, got {executor}: {result['response']}"
+        )
+      result.update(name=name, requested_model=model, expected_executor=expected_executor)
+      results.append(result)
+
+    evidence = {
+      "timestamp_utc": datetime.now(timezone.utc).isoformat(),
+      "nodes": node_infos,
+      "health": health,
+      "cases": results,
+      "result": "pass",
+    }
+    results_dir = Path(__file__).resolve().parent / "results"
+    results_dir.mkdir(exist_ok=True)
+    output_path = results_dir / "latest.json"
+    output_path.write_text(json.dumps(evidence, indent=2), encoding="utf-8")
+    print(json.dumps(evidence, indent=2))
+  finally:
+    session.close(wait_close=True)
+    shutil.rmtree(cache_dir, ignore_errors=True)
+
+
+if __name__ == "__main__":
+  sys.exit(main())

--- a/extensions/business/container_apps/tests/support.py
+++ b/extensions/business/container_apps/tests/support.py
@@ -7,6 +7,10 @@ from unittest.mock import MagicMock
 
 import numpy as _np
 
+# Load the real shared per-node helper before this test harness installs its
+# lightweight ``naeural_core.business`` module stubs.
+from naeural_core.utils import per_node_config as _per_node_config  # noqa: F401,E402
+
 
 def install_docker_stub_if_needed():
   """Provide the tiny docker-py surface these unit tests need."""

--- a/extensions/business/container_apps/tests/support.py
+++ b/extensions/business/container_apps/tests/support.py
@@ -7,9 +7,8 @@ from unittest.mock import MagicMock
 
 import numpy as _np
 
-# Load the real shared per-node helper before this test harness installs its
-# lightweight ``naeural_core.business`` module stubs.
-from naeural_core.utils import per_node_config as _per_node_config  # noqa: F401,E402
+# Keep the real package root so the business stubs do not poison later imports.
+import naeural_core as _naeural_core  # noqa: F401
 
 
 def install_docker_stub_if_needed():
@@ -194,23 +193,40 @@ class _DummyBasePlugin:
 
 def install_dummy_base_plugin():
   module_hierarchy = [
-    ('naeural_core', types.ModuleType('naeural_core')),
     ('naeural_core.business', types.ModuleType('naeural_core.business')),
     ('naeural_core.business.base', types.ModuleType('naeural_core.business.base')),
     ('naeural_core.business.base.web_app', types.ModuleType('naeural_core.business.base.web_app')),
   ]
 
+  missing = object()
+  previous_modules = {
+    name: sys.modules.get(name, missing)
+    for name, _module in module_hierarchy
+  }
   for name, module in module_hierarchy:
-    sys.modules.setdefault(name, module)
+    sys.modules[name] = module
 
+  leaf_name = 'naeural_core.business.base.web_app.base_tunnel_engine_plugin'
+  previous_modules[leaf_name] = sys.modules.get(leaf_name, missing)
   base_tunnel_mod = types.ModuleType('naeural_core.business.base.web_app.base_tunnel_engine_plugin')
   base_tunnel_mod.BaseTunnelEnginePlugin = _DummyBasePlugin
-  sys.modules['naeural_core.business.base.web_app.base_tunnel_engine_plugin'] = base_tunnel_mod
+  sys.modules[leaf_name] = base_tunnel_mod
+
+  def restore_modules():
+    for name, previous_module in previous_modules.items():
+      if previous_module is missing:
+        sys.modules.pop(name, None)
+      else:
+        sys.modules[name] = previous_module
+
+  return restore_modules
 
 
-install_dummy_base_plugin()
-
-from extensions.business.container_apps.container_app_runner import ContainerAppRunnerPlugin
+_restore_core_modules = install_dummy_base_plugin()
+try:
+  from extensions.business.container_apps.container_app_runner import ContainerAppRunnerPlugin
+finally:
+  _restore_core_modules()
 
 
 def make_container_app_runner():

--- a/extensions/business/deeploy/deeploy_mixin.py
+++ b/extensions/business/deeploy/deeploy_mixin.py
@@ -3282,6 +3282,7 @@ class _DeeployMixin:
     return None
 
   def _canonicalize_per_node_config_key(self, plugin_instance):
+    """Rewrite the supported public spelling and reject ambiguous instances."""
     present_keys = [
       key for key in PER_NODE_CONFIG_KEYS
       if key in plugin_instance

--- a/extensions/business/deeploy/deeploy_mixin.py
+++ b/extensions/business/deeploy/deeploy_mixin.py
@@ -5047,6 +5047,12 @@ class _DeeployMixin:
       deeploy_specs[DEEPLOY_KEYS.CURRENT_TARGET_NODES] = chainstore_peers
       deeploy_specs[DEEPLOY_KEYS.DATE_UPDATED] = self.time()
     base_pipeline[NetMonCt.DEEPLOY_SPECS] = self.deepcopy(deeploy_specs)
+    for plugin in base_pipeline.get(NetMonCt.PLUGINS, []):
+      if not isinstance(plugin, dict):
+        continue
+      for instance in plugin.get(self.ct.CONFIG_PLUGIN.K_INSTANCES, []) or []:
+        if isinstance(instance, dict):
+          self._canonicalize_per_node_config_key(instance)
     # TODO: Delegate service-specific persisted-pipeline preparation through
     # the managed-service abstraction when CockroachDB is no longer the only
     # service with generated per-node runtime material.

--- a/extensions/business/deeploy/tests/test_create_requests.py
+++ b/extensions/business/deeploy/tests/test_create_requests.py
@@ -217,6 +217,32 @@ class DeeployCreateRequestPreparationTests(unittest.TestCase):
     with self.assertRaisesRegex(ValueError, "duplicate aliases"):
       plugin._normalize_per_node_config({"byIndex": {}, "BY_INDEX": {}})
 
+  def test_per_node_config_rejects_duplicate_normalized_selectors(self):
+    plugin = make_deeploy_plugin()
+
+    with self.assertRaisesRegex(ValueError, "duplicate normalized index 1"):
+      plugin._normalize_per_node_config({
+        "byIndex": {
+          "01": {"ENV": {"NODE_ID": "first"}},
+          "1": {"ENV": {"NODE_ID": "second"}},
+        },
+      })
+    with self.assertRaisesRegex(ValueError, "duplicate node selector '1'"):
+      plugin._normalize_per_node_config({
+        "byNode": {
+          1: {"ENV": {"NODE_ID": "first"}},
+          "1": {"ENV": {"NODE_ID": "second"}},
+        },
+      })
+
+  def test_per_node_config_rejects_normalized_nested_alias(self):
+    plugin = make_deeploy_plugin()
+
+    with self.assertRaisesRegex(ValueError, "Nested .* overlays"):
+      plugin._normalize_per_node_config({
+        "byIndex": {"0": {"PerNodeConfig": {}}},
+      })
+
   def test_log_redaction_masks_per_node_config_and_token_keys(self):
     plugin = make_deeploy_plugin()
 

--- a/extensions/business/deeploy/tests/test_update_requests.py
+++ b/extensions/business/deeploy/tests/test_update_requests.py
@@ -3233,6 +3233,73 @@ class DeeployUpdateRequestPreparationTests(unittest.TestCase):
     self.assertEqual(updated["CHAINSTORE_PEERS"], expected_nodes)
     self.assertEqual(updated["PER_NODE_TARGET_NODES"], expected_nodes)
 
+  def test_scale_up_prepare_canonicalizes_persisted_per_node_config(self):
+    plugin = make_deeploy_plugin()
+    plugin.defaultdict = defaultdict
+    plugin.time = lambda: 1000
+    base_pipeline = {
+      "app_id": "app-1",
+      "pipeline_type": "Void",
+      "url": "",
+      "pipeline_params": {},
+      "deeploy_specs": {
+        DEEPLOY_KEYS.CURRENT_TARGET_NODES: ["0xai_node_a"],
+        DEEPLOY_KEYS.JOB_APP_TYPE: JOB_APP_TYPES.SERVICE,
+      },
+      "plugins": [{
+        "SIGNATURE": "CONTAINER_APP_RUNNER",
+        "INSTANCES": [{
+          "INSTANCE_ID": "stale-instance",
+          "perNodeConfig": {"byNode": {"0xai_node_b": {"ENV": {"NODE_ID": "2"}}}},
+        }],
+      }],
+    }
+
+    create_pipelines, _update_pipelines, _response_keys = plugin.prepare_create_update_pipelines(
+      base_pipeline=base_pipeline,
+      new_nodes=["0xai_node_b"],
+      update_nodes=[],
+      running_apps_for_job={},
+    )
+
+    instance = create_pipelines["0xai_node_b"]["plugins"][0]["INSTANCES"][0]
+    self.assertNotIn("perNodeConfig", instance)
+    self.assertEqual(
+      instance["PER_NODE_CONFIG"],
+      {"byNode": {"0xai_node_b": {"ENV": {"NODE_ID": "2"}}}},
+    )
+
+  def test_scale_up_prepare_rejects_duplicate_per_node_config_spellings(self):
+    plugin = make_deeploy_plugin()
+    plugin.defaultdict = defaultdict
+    plugin.time = lambda: 1000
+    base_pipeline = {
+      "app_id": "app-1",
+      "pipeline_type": "Void",
+      "url": "",
+      "pipeline_params": {},
+      "deeploy_specs": {
+        DEEPLOY_KEYS.CURRENT_TARGET_NODES: ["0xai_node_a"],
+        DEEPLOY_KEYS.JOB_APP_TYPE: JOB_APP_TYPES.SERVICE,
+      },
+      "plugins": [{
+        "SIGNATURE": "CONTAINER_APP_RUNNER",
+        "INSTANCES": [{
+          "INSTANCE_ID": "stale-instance",
+          "perNodeConfig": {"byNode": {}},
+          "PER_NODE_CONFIG": {"byNode": {}},
+        }],
+      }],
+    }
+
+    with self.assertRaisesRegex(ValueError, "Only one perNodeConfig spelling"):
+      plugin.prepare_create_update_pipelines(
+        base_pipeline=base_pipeline,
+        new_nodes=["0xai_node_b"],
+        update_nodes=[],
+        running_apps_for_job={},
+      )
+
 
 if __name__ == "__main__":
   unittest.main()

--- a/extensions/business/edge_inference_api/base_inference_api.py
+++ b/extensions/business/edge_inference_api/base_inference_api.py
@@ -570,6 +570,28 @@ class BaseInferenceApiPlugin(
     """
     return self._get_capacity_free() > 0
 
+  def _get_balancing_capabilities(self):
+    """Return stable capabilities advertised to balancing peers.
+
+    Subclasses may expose request-relevant capabilities such as model ids.
+    Values must remain JSON serializable because capacity records are stored in
+    ChainStore.
+
+    Returns
+    -------
+    dict
+      Capability fields for the current plugin instance.
+    """
+    return {}
+
+  def _can_execute_request(self, request_data):
+    """Return whether the current instance can satisfy a tracked request."""
+    return True
+
+  def _capacity_record_can_execute_request(self, record, request_data):
+    """Return whether a peer capacity record can satisfy a tracked request."""
+    return True
+
   def _decrement_active_requests(self):
     """Decrease the active request metric without allowing underflow.
 
@@ -731,6 +753,7 @@ class BaseInferenceApiPlugin(
       'capacity_used': capacity_used,
       'capacity_free': capacity_free,
       'max_cstore_bytes': self._get_max_cstore_bytes(),
+      'capabilities': self._get_balancing_capabilities(),
       # Keep both fields: capacity_free is numeric slot availability, while
       # accepting_requests is admission/readiness policy and may be false even
       # when slots are physically free, e.g. during serving cold start.
@@ -1050,7 +1073,7 @@ class BaseInferenceApiPlugin(
       target_peer=effective_target,
     )
 
-  def _select_execution_peer(self):
+  def _select_execution_peer(self, request_data=None):
     """Select an eligible peer for delegated execution.
 
     Returns
@@ -1072,6 +1095,8 @@ class BaseInferenceApiPlugin(
       if record.get('balancer_group') != self._normalize_balancing_group():
         continue
       if record.get('signature') != self.get_signature():
+        continue
+      if not self._capacity_record_can_execute_request(record, request_data):
         continue
       updated_at = record.get('updated_at')
       if not isinstance(updated_at, (int, float)):
@@ -1388,12 +1413,12 @@ class BaseInferenceApiPlugin(
     """
     if self._is_request_terminal(request_data):
       return True
-    if self._can_accept_execution():
+    if self._can_accept_execution() and self._can_execute_request(request_data):
       if not self._reserve_execution_slot(request_id):
         return False
       request_data['execution_mode'] = 'local'
       return self._dispatch_local_request(request_id=request_id, request_data=request_data)
-    target_record = self._select_execution_peer()
+    target_record = self._select_execution_peer(request_data=request_data)
     if not target_record:
       return False
     delegation_id, err = self._write_delegated_request(
@@ -2220,6 +2245,28 @@ class BaseInferenceApiPlugin(
         continue
       owned_payloads.setdefault(request_id, payload)
     return owned_payloads
+
+  def _handle_structured_inference_batch(self, inferences_by_model, data=None):
+    """Handle every structured inference in the current capture batch.
+
+    Loopback captures may prepend unrelated structured payloads to the API
+    request. Reading only structured-data index zero can therefore discard the
+    owned inference even though the serving process completed it.
+
+    Parameters
+    ----------
+    inferences_by_model : dict[str, list[dict]] or None
+      Structured inference lists keyed by serving process.
+    data : list[dict] or None, optional
+      Structured inputs aligned with each model's inference list.
+    """
+    if not isinstance(inferences_by_model, dict):
+      return
+    for model_inferences in inferences_by_model.values():
+      if not isinstance(model_inferences, list):
+        continue
+      self.handle_inferences(inferences=model_inferences, data=data)
+    return
 
   def _setup_semaphore_env(self):
     """
@@ -3080,6 +3127,9 @@ class BaseInferenceApiPlugin(
         request_data['delegation_expires_at'] = delegation_context.get('expires_at')
 
       if force_local_execution:
+        if not self._can_execute_request(request_data):
+          self._fail_request(request_id, 'Executor cannot satisfy the request capabilities.')
+          return request_data['result']
         if not self._reserve_execution_slot(request_id):
           self._fail_request(request_id, 'Executor has no free capacity.')
           return request_data['result']
@@ -3101,10 +3151,13 @@ class BaseInferenceApiPlugin(
               error_message='Inference API pending queue is full.',
             )
       else:
-        self._dispatch_local_request(
-          request_id=request_id,
-          request_data=request_data,
-        )
+        if self._can_execute_request(request_data):
+          self._dispatch_local_request(
+            request_id=request_id,
+            request_data=request_data,
+          )
+        else:
+          self._fail_request(request_id, 'Local instance cannot satisfy the request capabilities.')
 
       if delegated_execution or force_local_execution:
         return request_data
@@ -3165,8 +3218,11 @@ class BaseInferenceApiPlugin(
       self._retry_same_peer_delegations()
       self._last_balancing_mailbox_poll = now_ts
     data = self.dataapi_struct_datas()
-    inferences = self.dataapi_struct_data_inferences()
-    self.handle_inferences(inferences=inferences, data=data)
+    inferences_by_model = self.dataapi_struct_datas_inferences()
+    self._handle_structured_inference_batch(
+      inferences_by_model=inferences_by_model,
+      data=data,
+    )
     self._reconcile_requests()
     self._publish_executor_results()
     self._cleanup_balancing_state()

--- a/extensions/business/edge_inference_api/llm_inference_api.py
+++ b/extensions/business/edge_inference_api/llm_inference_api.py
@@ -94,6 +94,7 @@ from typing import Any, Dict, List, Optional, Tuple
 _CONFIG = {
   **BasePlugin.CONFIG,
   "AI_ENGINE": "llama_cpp_small",
+  "SERVED_MODELS": [],
 
   "API_TITLE": "LLM Inference API",
 
@@ -110,6 +111,81 @@ _CONFIG = {
 
 class LLMInferenceApiPlugin(BasePlugin):
   CONFIG = _CONFIG
+
+  def _get_local_model_ids(self):
+    """Return normalized model identifiers served by this instance.
+
+    Explicit ``SERVED_MODELS`` aliases are combined with the effective
+    per-node AI engine and startup model identifiers. This lets API clients use
+    stable public aliases while retaining useful engine/model ids for backward
+    compatibility.
+    """
+    model_ids = set()
+    configured_aliases = getattr(self, 'cfg_served_models', [])
+    if isinstance(configured_aliases, str):
+      configured_aliases = [configured_aliases]
+    if isinstance(configured_aliases, (list, tuple, set)):
+      model_ids.update(
+        str(value).strip()
+        for value in configured_aliases
+        if isinstance(value, str) and value.strip()
+      )
+
+    ai_engines = getattr(self, 'cfg_ai_engine', None)
+    if isinstance(ai_engines, str):
+      ai_engines = [ai_engines]
+    if isinstance(ai_engines, (list, tuple, set)):
+      model_ids.update(
+        str(value).strip()
+        for value in ai_engines
+        if isinstance(value, str) and value.strip()
+      )
+
+    startup_params = getattr(self, 'cfg_startup_ai_engine_params', {})
+    pending = [startup_params]
+    while pending:
+      current = pending.pop()
+      if not isinstance(current, dict):
+        continue
+      for key, value in current.items():
+        if isinstance(value, dict):
+          pending.append(value)
+        elif key in {'MODEL_NAME', 'MODEL_INSTANCE_ID'} and isinstance(value, str) and value.strip():
+          model_ids.add(value.strip())
+        elif key == 'MODEL_PATH' and isinstance(value, str) and value.strip():
+          model_ids.add(value.rstrip('/').rsplit('/', 1)[-1])
+    return sorted(model_ids)
+
+  def _get_balancing_capabilities(self):
+    return {'models': self._get_local_model_ids()}
+
+  @staticmethod
+  def _get_requested_model(request_data):
+    if not isinstance(request_data, dict):
+      return None
+    parameters = request_data.get('parameters')
+    if not isinstance(parameters, dict):
+      return None
+    model = parameters.get('model')
+    if not isinstance(model, str):
+      return None
+    return model.strip() or None
+
+  def _can_execute_request(self, request_data):
+    requested_model = self._get_requested_model(request_data)
+    return requested_model is None or requested_model in self._get_local_model_ids()
+
+  def _capacity_record_can_execute_request(self, record, request_data):
+    requested_model = self._get_requested_model(request_data)
+    if requested_model is None:
+      return True
+    if not isinstance(record, dict):
+      return False
+    capabilities = record.get('capabilities')
+    if not isinstance(capabilities, dict):
+      return False
+    models = capabilities.get('models')
+    return isinstance(models, list) and requested_model in models
 
   """VALIDATION SECTION"""
   if True:
@@ -334,6 +410,7 @@ class LLMInferenceApiPlugin(BasePlugin):
     def predict(
         self,
         messages: List[Dict[str, Any]],
+        model: Optional[str] = None,
         temperature: float = 0.7,
         max_tokens: int = 512,
         top_p: float = 1.0,
@@ -350,6 +427,8 @@ class LLMInferenceApiPlugin(BasePlugin):
       ----------
       messages : list of dict
         Chat history for the model to complete.
+      model : str or None, optional
+        Requested model identifier used for local execution or peer routing.
       temperature : float, optional
         Sampling temperature.
       max_tokens : int, optional
@@ -374,6 +453,7 @@ class LLMInferenceApiPlugin(BasePlugin):
       """
       return super(LLMInferenceApiPlugin, self).predict(
         messages=messages,
+        model=model,
         temperature=temperature,
         max_tokens=max_tokens,
         top_p=top_p,
@@ -390,6 +470,7 @@ class LLMInferenceApiPlugin(BasePlugin):
     def predict_async(
         self,
         messages: List[Dict[str, Any]],
+        model: Optional[str] = None,
         temperature: float = 0.7,
         max_tokens: int = 512,
         top_p: float = 1.0,
@@ -407,6 +488,8 @@ class LLMInferenceApiPlugin(BasePlugin):
       ----------
       messages : list of dict
         Chat history for the model to complete.
+      model : str or None, optional
+        Requested model identifier used for local execution or peer routing.
       temperature : float, optional
         Sampling temperature.
       max_tokens : int, optional
@@ -434,6 +517,7 @@ class LLMInferenceApiPlugin(BasePlugin):
       """
       return super(LLMInferenceApiPlugin, self).predict_async(
         messages=messages,
+        model=model,
         temperature=temperature,
         max_tokens=max_tokens,
         top_p=top_p,
@@ -449,6 +533,7 @@ class LLMInferenceApiPlugin(BasePlugin):
     def create_chat_completion(
         self,
         messages: List[Dict[str, Any]],
+        model: Optional[str] = None,
         temperature: float = 0.7,
         max_tokens: int = 512,
         top_p: float = 1.0,
@@ -465,6 +550,8 @@ class LLMInferenceApiPlugin(BasePlugin):
       ----------
       messages : list of dict
         Chat history for the model to complete.
+      model : str or None, optional
+        Requested model identifier used for local execution or peer routing.
       temperature : float, optional
         Sampling temperature.
       max_tokens : int, optional
@@ -489,6 +576,7 @@ class LLMInferenceApiPlugin(BasePlugin):
       """
       return self.predict(
         messages=messages,
+        model=model,
         temperature=temperature,
         max_tokens=max_tokens,
         top_p=top_p,
@@ -503,6 +591,7 @@ class LLMInferenceApiPlugin(BasePlugin):
     def create_chat_completion_async(
         self,
         messages: List[Dict[str, Any]],
+        model: Optional[str] = None,
         temperature: float = 0.7,
         max_tokens: int = 512,
         top_p: float = 1.0,
@@ -519,6 +608,8 @@ class LLMInferenceApiPlugin(BasePlugin):
       ----------
       messages : list of dict
         Chat history for the model to complete.
+      model : str or None, optional
+        Requested model identifier used for local execution or peer routing.
       temperature : float, optional
         Sampling temperature.
       max_tokens : int, optional
@@ -543,6 +634,7 @@ class LLMInferenceApiPlugin(BasePlugin):
       """
       return self.predict_async(
         messages=messages,
+        model=model,
         temperature=temperature,
         max_tokens=max_tokens,
         top_p=top_p,
@@ -561,6 +653,7 @@ class LLMInferenceApiPlugin(BasePlugin):
         messages: List[Dict[str, Any]],
         temperature: float,
         max_tokens: int,
+        model: Optional[str] = None,
         top_p: float = 1.0,
         repeat_penalty: float = 1.0,
         response_format: Optional[Dict[str, Any]] = None,
@@ -573,6 +666,8 @@ class LLMInferenceApiPlugin(BasePlugin):
       ----------
       messages : list of dict
         Chat history for the model to complete.
+      model : str or None, optional
+        Requested model identifier used for capability-aware routing.
       temperature : float
         Sampling temperature.
       max_tokens : int
@@ -591,6 +686,8 @@ class LLMInferenceApiPlugin(BasePlugin):
       str or None
         Error message when validation fails, otherwise None.
       """
+      if model is not None and (not isinstance(model, str) or not model.strip()):
+        return "`model` must be a non-empty string when provided."
       err = self.check_messages(messages)
       if err is not None:
         return err
@@ -610,6 +707,7 @@ class LLMInferenceApiPlugin(BasePlugin):
         messages: List[Dict[str, Any]],
         temperature: float,
         max_tokens: int,
+        model: Optional[str] = None,
         top_p: float = 1.0,
         repeat_penalty: float = 1.0,
         response_format: Optional[Dict[str, Any]] = None,
@@ -622,6 +720,8 @@ class LLMInferenceApiPlugin(BasePlugin):
       ----------
       messages : list of dict
         Chat history for the model to complete.
+      model : str or None, optional
+        Requested model identifier retained in the tracked request.
       temperature : float
         Sampling temperature.
       max_tokens : int
@@ -643,7 +743,7 @@ class LLMInferenceApiPlugin(BasePlugin):
       normalized_messages = self.normalize_messages(messages)
       # No need to capture err_msg here, already validated in check_predict_params
       response_format, _ = self.check_and_normalize_response_format(response_format=response_format)
-      return {
+      parameters = {
         'messages': normalized_messages,
         'temperature': temperature,
         'max_tokens': max_tokens,
@@ -652,6 +752,9 @@ class LLMInferenceApiPlugin(BasePlugin):
         'response_format': response_format,
         **kwargs
       }
+      if model is not None:
+        parameters['model'] = model.strip()
+      return parameters
 
     def compute_payload_kwargs_from_predict_params(
         self,
@@ -682,6 +785,7 @@ class LLMInferenceApiPlugin(BasePlugin):
       if repeat_penalty is not None:
         jeeves_content['REPETITION_PENALTY'] = repeat_penalty
       jeeves_content.pop('REPEAT_PENALTY', None)
+      jeeves_content.pop('MODEL', None)
       jeeves_content[LlmCT.REQUEST_ID] = request_id
       jeeves_content[LlmCT.REQUEST_TYPE] = 'LLM'
       return {
@@ -816,9 +920,10 @@ class LLMInferenceApiPlugin(BasePlugin):
       if request_data['status'] != self.STATUS_PENDING:
         return
 
+      resolved_model_name = model_name or request_data.get('parameters', {}).get('model')
       response_payload = self.build_completion_response(
         request_id=request_id,
-        model_name=model_name or request_data['model'],
+        model_name=resolved_model_name,
         inference=inference,
         request_data=request_data
       )
@@ -834,7 +939,7 @@ class LLMInferenceApiPlugin(BasePlugin):
       # TODO: adapt this to match OpenAI-style response structure if flag active
       self._requests[request_id]['result'] = {
         'REQUEST_ID': request_id,
-        'MODEL_NAME': model_name,
+        'MODEL_NAME': resolved_model_name,
         'TEXT_RESPONSE': text_response,
         LlmCT.FULL_OUTPUT: full_output,
       }

--- a/extensions/business/edge_inference_api/test_base_inference_api_balancing.py
+++ b/extensions/business/edge_inference_api/test_base_inference_api_balancing.py
@@ -171,6 +171,9 @@ class _FakeBasePlugin:
   def dataapi_struct_data_inferences(self):
     return []
 
+  def dataapi_struct_datas_inferences(self):
+    return {}
+
   def create_postponed_request(self, solver_method=None, method_kwargs=None):
     return {
       "postponed": True,
@@ -451,6 +454,14 @@ class BaseInferenceApiBalancingTests(unittest.TestCase):
     self.assertLessEqual(due_seconds, 420.0)
     self.assertEqual(due_seconds, plugin._get_capacity_refresh_due_seconds())  # pylint: disable=protected-access
 
+  def test_capacity_record_advertises_instance_capabilities(self):
+    plugin = self._make_plugin()
+    plugin._get_balancing_capabilities = lambda: {"models": ["model-a"]}  # pylint: disable=protected-access
+
+    record = plugin._build_capacity_record_snapshot()  # pylint: disable=protected-access
+
+    self.assertEqual(record["capabilities"], {"models": ["model-a"]})
+
   def test_select_execution_peer_prefers_highest_capacity_free_and_ignores_stale(self):
     plugin = self._make_plugin()
     plugin.chainstore_hgetall_values[plugin._capacity_hkey()] = {
@@ -515,6 +526,50 @@ class BaseInferenceApiBalancingTests(unittest.TestCase):
     selected = plugin._select_execution_peer()  # pylint: disable=protected-access
 
     self.assertEqual(selected["instance_id"], "inst-b")
+
+  def test_requested_capability_skips_local_and_filters_remote_peers(self):
+    plugin = self._make_plugin()
+    plugin._can_execute_request = (  # pylint: disable=protected-access
+      lambda request_data: request_data["parameters"].get("model") == "model-local"
+    )
+    plugin._capacity_record_can_execute_request = (  # pylint: disable=protected-access
+      lambda record, request_data: request_data["parameters"].get("model")
+      in (record.get("capabilities") or {}).get("models", [])
+    )
+    plugin.chainstore_hgetall_values[plugin._capacity_hkey()] = {
+      "wrong-model": {
+        "ee_addr": "peer-wrong",
+        "instance_id": "wrong",
+        "balancer_group": plugin._normalize_balancing_group(),
+        "signature": plugin.get_signature(),
+        "capacity_free": 5,
+        "capabilities": {"models": ["model-other"]},
+        "updated_at": plugin.time(),
+      },
+      "requested-model": {
+        "ee_addr": "peer-model-b",
+        "instance_id": "model-b",
+        "balancer_group": plugin._normalize_balancing_group(),
+        "signature": plugin.get_signature(),
+        "capacity_free": 1,
+        "capabilities": {"models": ["model-b"]},
+        "updated_at": plugin.time(),
+      },
+    }
+    request_id, request_data = plugin.register_request(
+      subject="anonymous",
+      parameters={"model": "model-b"},
+    )
+
+    scheduled = plugin._attempt_schedule_request(  # pylint: disable=protected-access
+      request_id=request_id,
+      request_data=request_data,
+      endpoint_name="predict",
+    )
+
+    self.assertTrue(scheduled)
+    self.assertEqual(request_data["execution_mode"], "delegated")
+    self.assertEqual(request_data["delegation_target_addr"], "peer-model-b")
 
   def test_write_delegated_request_targets_only_executor(self):
     plugin = self._make_plugin()
@@ -981,6 +1036,22 @@ class BaseInferenceApiBalancingTests(unittest.TestCase):
         owned_request_id: {"request_id": owned_request_id, "metadata": {"source": "owned"}},
       },
     )
+
+  def test_structured_inference_batch_keeps_owned_result_after_irrelevant_input(self):
+    plugin = self._make_plugin()
+    handled = []
+    plugin.handle_inferences = lambda inferences, data: handled.append((inferences, data))
+    inputs = [{"kind": "unrelated"}, {"request_id": "owned-1"}]
+    inferences = {
+      "fake-engine": [
+        {"IS_VALID": False, "text": ""},
+        {"IS_VALID": True, "REQUEST_ID": "owned-1", "text": "done"},
+      ],
+    }
+
+    plugin._handle_structured_inference_batch(inferences, data=inputs)  # pylint: disable=protected-access
+
+    self.assertEqual(handled, [(inferences["fake-engine"], inputs)])
 
 
 if __name__ == "__main__":

--- a/extensions/business/edge_inference_api/test_llm_inference_api.py
+++ b/extensions/business/edge_inference_api/test_llm_inference_api.py
@@ -11,6 +11,7 @@ class _FakeBasePlugin:
     "AI_ENGINE": "llama_cpp_small",
   }
   STATUS_PENDING = "pending"
+  STATUS_COMPLETED = "completed"
 
   @staticmethod
   def endpoint(method="get", require_token=False, streaming_type=None, chunk_size=1024 * 1024):  # pylint: disable=unused-argument
@@ -70,8 +71,56 @@ LLMInferenceApiPlugin = _load_plugin_class()
 
 
 class LLMInferenceApiPluginTests(unittest.TestCase):
-  def test_payload_uses_llm_serving_uppercase_contract(self):
+  @staticmethod
+  def _make_plugin(**overrides):
     plugin = LLMInferenceApiPlugin()
+    plugin.cfg_ai_engine = overrides.get("AI_ENGINE", "llama_cpp_small")
+    plugin.cfg_served_models = overrides.get("SERVED_MODELS", [])
+    plugin.cfg_startup_ai_engine_params = overrides.get("STARTUP_AI_ENGINE_PARAMS", {})
+    return plugin
+
+  def test_model_capability_uses_explicit_aliases_and_effective_ai_config(self):
+    plugin = self._make_plugin(
+      AI_ENGINE="llama_cpp_medium",
+      SERVED_MODELS=["friendly-model-b"],
+      STARTUP_AI_ENGINE_PARAMS={"MODEL_NAME": "org/model-b"},
+    )
+
+    capabilities = plugin._get_balancing_capabilities()  # pylint: disable=protected-access
+
+    self.assertEqual(
+      capabilities["models"],
+      ["friendly-model-b", "llama_cpp_medium", "org/model-b"],
+    )
+
+  def test_model_matching_requires_requested_model_locally_and_remotely(self):
+    plugin = self._make_plugin(SERVED_MODELS=["model-a"])
+    request_data = {"parameters": {"model": "model-b"}}
+
+    self.assertFalse(plugin._can_execute_request(request_data))  # pylint: disable=protected-access
+    self.assertFalse(  # pylint: disable=protected-access
+      plugin._capacity_record_can_execute_request(
+        {"capabilities": {"models": ["model-a"]}},
+        request_data,
+      )
+    )
+    self.assertTrue(  # pylint: disable=protected-access
+      plugin._capacity_record_can_execute_request(
+        {"capabilities": {"models": ["model-b"]}},
+        request_data,
+      )
+    )
+
+  def test_unspecified_model_preserves_local_first_compatibility(self):
+    plugin = self._make_plugin(SERVED_MODELS=["model-a"])
+
+    self.assertTrue(plugin._can_execute_request({"parameters": {}}))  # pylint: disable=protected-access
+    self.assertTrue(  # pylint: disable=protected-access
+      plugin._capacity_record_can_execute_request({}, {"parameters": {}})
+    )
+
+  def test_payload_uses_llm_serving_uppercase_contract(self):
+    plugin = self._make_plugin()
 
     payload = plugin.compute_payload_kwargs_from_predict_params(
       request_id="req-1",
@@ -85,6 +134,7 @@ class LLMInferenceApiPluginTests(unittest.TestCase):
           "response_format": {"type": "json_object"},
           "seed": 123,
           "frequency_penalty": 0.2,
+          "model": "llama_cpp_small",
         }
       },
     )
@@ -98,6 +148,7 @@ class LLMInferenceApiPluginTests(unittest.TestCase):
     self.assertEqual(payload["JEEVES_CONTENT"]["REPETITION_PENALTY"], 1.1)
     self.assertEqual(payload["JEEVES_CONTENT"]["SEED"], 123)
     self.assertEqual(payload["JEEVES_CONTENT"]["FREQUENCY_PENALTY"], 0.2)
+    self.assertNotIn("MODEL", payload["JEEVES_CONTENT"])
     self.assertNotIn("REPEAT_PENALTY", payload["JEEVES_CONTENT"])
 
   def test_filter_valid_inference_accepts_lowercase_request_id(self):
@@ -171,6 +222,31 @@ class LLMInferenceApiPluginTests(unittest.TestCase):
 
     self.assertTrue(plugin.filter_valid_inference(inference))
     self.assertEqual(inference["REQUEST_ID"], "req-8")
+
+  def test_handle_inference_preserves_requested_model_when_backend_omits_model_name(self):
+    plugin = self._make_plugin()
+    plugin._requests = {  # pylint: disable=protected-access
+      "req-9": {
+        "status": plugin.STATUS_PENDING,
+        "parameters": {"model": "public-model-alias"},
+        "metadata": {},
+      },
+    }
+    plugin._metrics = {"requests_completed": 0}  # pylint: disable=protected-access
+    plugin.time = lambda: 10.0
+    plugin._decrement_active_requests = lambda: None  # pylint: disable=protected-access
+    plugin._annotate_result_with_node_roles = lambda result_payload, request_data: result_payload  # pylint: disable=protected-access
+
+    plugin.handle_single_inference(
+      {
+        "REQUEST_ID": "req-9",
+        "text": "done",
+        "FULL_OUTPUT": None,
+      },
+      model_name=None,
+    )
+
+    self.assertEqual(plugin._requests["req-9"]["result"]["MODEL_NAME"], "public-model-alias")
 
 
 if __name__ == "__main__":

--- a/extensions/utils/per_node_config.py
+++ b/extensions/utils/per_node_config.py
@@ -133,20 +133,27 @@ def normalize_config(
       raise ValueError(f"{label}.byIndex key {raw_index!r} must be an integer index.") from exc
     if index < 0:
       raise ValueError(f"{label}.byIndex key {raw_index!r} must be non-negative.")
+    if index in normalized_by_index:
+      raise ValueError(f"{label}.byIndex contains duplicate normalized index {index}.")
     normalized_by_index[index] = overlay
 
   normalized_by_node = {}
   for raw_node, overlay in by_node.items():
     if not isinstance(overlay, dict):
       raise ValueError(f"{label}.byNode[{raw_node!r}] must be a dictionary.")
-    normalized_by_node[str(raw_node)] = overlay
+    node = str(raw_node)
+    if node in normalized_by_node:
+      raise ValueError(f"{label}.byNode contains duplicate node selector {node!r}.")
+    normalized_by_node[node] = overlay
 
+  normalized_config_keys = {str(key).upper() for key in config_keys}
+  normalized_system_keys = {str(key).upper() for key in system_keys}
   for overlay in [default_overlay, *normalized_by_index.values(), *normalized_by_node.values()]:
     for key in overlay:
       normalized_key = str(key).upper()
-      if key in config_keys:
+      if normalized_key in normalized_config_keys:
         raise ValueError(f"Nested {label} overlays are not supported.")
-      if normalized_key in system_keys:
+      if normalized_key in normalized_system_keys:
         raise ValueError(
           f"{label} cannot override system-managed or preflighted key '{key}'."
         )

--- a/extensions/utils/per_node_config.py
+++ b/extensions/utils/per_node_config.py
@@ -1,8 +1,16 @@
+"""Compatibility helpers for Edge per-node deployment configuration.
+
+Edge accepts ``perNodeConfig`` at its public Deeploy boundary and rewrites it
+to canonical ``PER_NODE_CONFIG`` before dispatch. Container runners consume
+that canonical runtime field.
+"""
+
 from copy import deepcopy as _deepcopy
 
 
 CANONICAL_PER_NODE_CONFIG_KEY = "PER_NODE_CONFIG"
 PER_NODE_TARGET_NODES_KEY = "PER_NODE_TARGET_NODES"
+# Accepted Deeploy boundary spellings; dispatched instances use the canonical key.
 PER_NODE_CONFIG_KEYS = ("perNodeConfig", CANONICAL_PER_NODE_CONFIG_KEY)
 PER_NODE_CONFIG_STRUCTURED_KEYS = {
   "default",


### PR DESCRIPTION
## Summary
- advertise effective LLM model aliases and engine/model identifiers in balancing capacity records
- keep compatible requests local and delegate exact-model requests to a peer advertising that model
- canonicalize public and persisted `perNodeConfig` input to `PER_NODE_CONFIG` before create/update dispatch
- reject duplicate spellings, ambiguous normalized selectors, and nested per-node aliases before deployment
- consume complete structured inference batches so loopback results are not lost behind unrelated inputs
- add an isolated two-node CPU LLM Compose testbed and validator
- keep container/Deeploy tests standalone from the unreleased Core helper and order independent

## Dependency
Pair with Ratio1/naeural_core#221. Edge owns the public `perNodeConfig` compatibility boundary and sends canonical `PER_NODE_CONFIG`; Core materializes it before business validation and serving startup.

## Verification
- focused inference/container tests: 57 passed
- Deeploy create/update tests: 118 passed
- standalone Deeploy/container compatibility suite: 128 passed in both module orders
- production module `py_compile` checks passed
- clean isolated two-node E2E passed on the final runtime patches
  - node 1 local `llama-1b` executed on node 1
  - node 2 local `qwen-0.8b` executed on node 2
  - node 1 request for `qwen-0.8b` executed on node 2
  - node 2 request for `llama-1b` executed on node 1
- `git diff --check` passed

## Review
The final Core-only, Edge-only, and cross-repo challenger reviews found no remaining actionable issues.