### PR TITLE
feat: add CockroachDB verified TLS lifecycle

### DIFF
--- a/docker-compose/deeploy-crdb-verify-full.yaml
+++ b/docker-compose/deeploy-crdb-verify-full.yaml
@@ -1,0 +1,87 @@
+name: deeploy-crdb-verify-full
+
+x-edge-env: &edge-env
+  EE_CONFIG: /edge_node/docker-compose/deeploy-testbed/config_startup_deeploy_testbed.json
+  EE_DEVICE: cpu
+  EE_ETH_ENABLED: "false"
+  EE_EVM_NET: devnet
+  EE_DAUTH_URL: N/A
+  EE_MQTT_HOST: deeploy_verify_mqtt
+  EE_MQTT_PORT: "1883"
+  EE_MQTT_USER: ""
+  EE_MQTT: ""
+  EE_MQTT_SUBTOPIC: address
+  EE_MQTT_SECURED: "false"
+  EE_MINIO_ACCESS_KEY: ""
+  EE_MINIO_ENDPOINT: ""
+  EE_MINIO_SECRET_KEY: ""
+  EE_MINIO_SECURE: "false"
+  EE_MINIO_UPLOAD_BUCKET: ""
+  EE_SECURED: "0"
+  EE_TUNNEL_ENGINE: none
+
+x-edge-node: &edge-node
+  image: local_edge_node_deeploy_0009
+  build:
+    context: ..
+    dockerfile: Dockerfile_devnet
+  privileged: true
+  restart: "no"
+  command: ["python3", "/edge_node/docker-compose/deeploy-testbed/device_no_extra_packages.py"]
+  depends_on:
+    deeploy_verify_mqtt:
+      condition: service_healthy
+  environment: *edge-env
+  volumes:
+    - ./deeploy-testbed:/edge_node/docker-compose/deeploy-testbed:ro
+
+services:
+  deeploy_verify_mqtt:
+    image: eclipse-mosquitto:2
+    restart: "no"
+    volumes:
+      - ./deeploy-testbed/mosquitto.conf:/mosquitto/config/mosquitto.conf:ro
+    healthcheck:
+      test: ["CMD-SHELL", "mosquitto_pub -h localhost -p 1883 -t deeploy_verify/health -m ok >/dev/null 2>&1"]
+      interval: 2s
+      timeout: 2s
+      retries: 20
+
+  deeploy_verify_node_1:
+    <<: *edge-node
+    environment:
+      <<: *edge-env
+      EE_ID: deeploy_verify_node_1
+      EE_SUPERVISOR: "false"
+    volumes:
+      - deeploy_verify_node_1_cache:/edge_node/_local_cache
+      - ./deeploy-testbed:/edge_node/docker-compose/deeploy-testbed:ro
+
+  deeploy_verify_node_2:
+    <<: *edge-node
+    environment:
+      <<: *edge-env
+      EE_ID: deeploy_verify_node_2
+      EE_SUPERVISOR: "false"
+    volumes:
+      - deeploy_verify_node_2_cache:/edge_node/_local_cache
+      - ./deeploy-testbed:/edge_node/docker-compose/deeploy-testbed:ro
+
+  deeploy_verify_node_3:
+    <<: *edge-node
+    environment:
+      <<: *edge-env
+      EE_ID: deeploy_verify_node_3
+      EE_SUPERVISOR: "false"
+    volumes:
+      - deeploy_verify_node_3_cache:/edge_node/_local_cache
+      - ./deeploy-testbed:/edge_node/docker-compose/deeploy-testbed:ro
+
+volumes:
+  deeploy_verify_node_1_cache:
+  deeploy_verify_node_2_cache:
+  deeploy_verify_node_3_cache:
+
+networks:
+  default:
+    name: deeploy-crdb-verify-full

--- a/docker-compose/deeploy-crdb-verify-full/README.md
+++ b/docker-compose/deeploy-crdb-verify-full/README.md
@@ -1,0 +1,30 @@
+# CockroachDB Verify-Full Testbed
+
+This local-only bed starts three real edge runtimes on a private broker. The
+validator then uses the edge certificate-preparation helper and the published
+CockroachDB service image to run a three-node SQL cluster on the same isolated
+network. No dAuth, Cloudflare, remote node, or live Deeploy resource is used.
+
+Run from the `edge_node` worktree root:
+
+```bash
+docker compose -f docker-compose/deeploy-crdb-verify-full.yaml config --quiet
+docker compose -f docker-compose/deeploy-crdb-verify-full.yaml up -d --build
+PYTHONPATH=/mnt/c/repos/naeural_client:. /home/bleot/venvs/umbrella313/bin/python \
+  docker-compose/deeploy-crdb-verify-full/validate_workflow.py
+docker compose -f docker-compose/deeploy-crdb-verify-full.yaml down -v --remove-orphans
+```
+
+The validator checks DNS hostname verification, wrong-host/wrong-CA/plaintext
+rejection, password authentication, three-node membership, data persistence
+across full certificate regeneration, delayed third-node convergence, and a
+packet capture with unique SQL canaries. It deletes raw captures, certificates,
+containers, networks, and CockroachDB stores before exiting.
+
+The direct SQL runtime is deliberate: it isolates the certificate and wire
+contract from Cloudflare availability while still using the exact published
+CockroachDB binary image. Certificates are produced through the production
+secure-config preparation path and consumed from its emitted per-node overlays.
+Manager update/replay behavior and dapp payload construction are covered by
+focused tests; this bed does not simulate wallet payment/signing or dispatch the
+database containers through live Container App Runner instances.

--- a/docker-compose/deeploy-crdb-verify-full/validate_workflow.py
+++ b/docker-compose/deeploy-crdb-verify-full/validate_workflow.py
@@ -1,0 +1,257 @@
+#!/usr/bin/env python3
+import hashlib
+import os
+from pathlib import Path
+import shutil
+import subprocess
+import tempfile
+import time
+
+from cryptography import x509
+
+from extensions.business.deeploy.tests.support import make_deeploy_plugin, make_inputs, make_plugin_entry
+
+
+NETWORK = "deeploy-crdb-verify-full"
+IMAGE = os.environ.get("CRDB_IMAGE", "ghcr.io/ratio1/deeploy-cockroachdb-service:main")
+CLIENT_IMAGE = os.environ.get("CRDB_CLIENT_IMAGE", "postgres:16-alpine")
+SNIFFER_IMAGE = os.environ.get("CRDB_SNIFFER_IMAGE", "nicolaka/netshoot:v0.13")
+HOSTNAME = "crdb-client.test"
+NODES = ["verify_crdb_1", "verify_crdb_2", "verify_crdb_3"]
+ALIASES = ["roach1", "roach2", "roach3"]
+RELAY = "verify_crdb_relay"
+CLIENT = "verify_crdb_client"
+PASSWORD = "verify_full_disposable_password"
+
+
+def run(args, *, check=True, capture=False, input_text=None, timeout=None):
+  result = subprocess.run(
+    args,
+    check=False,
+    text=True,
+    input=input_text,
+    stdout=subprocess.PIPE if capture else None,
+    stderr=subprocess.PIPE if capture else None,
+    timeout=timeout,
+  )
+  if check and result.returncode != 0:
+    detail = (result.stderr or result.stdout or "").strip()
+    raise RuntimeError(f"Command failed ({result.returncode}): {' '.join(args)}\n{detail}")
+  return result
+
+
+def docker(*args, **kwargs):
+  return run(["docker", *args], **kwargs)
+
+
+def write_bundle(root, bundle):
+  for index, node in enumerate(NODES):
+    cert_dir = root / f"certs-{index + 1}"
+    cert_dir.mkdir(parents=True, exist_ok=True)
+    env = bundle[node]
+    (cert_dir / "ca.crt").write_text(env["CRDB_CA_CRT"], encoding="ascii")
+    (cert_dir / "node.crt").write_text(env["CRDB_NODE_CRT"], encoding="ascii")
+    (cert_dir / "node.key").write_text(env["CRDB_NODE_KEY"], encoding="ascii")
+    if index == 0:
+      (cert_dir / "client.root.crt").write_text(env["CRDB_CLIENT_ROOT_CRT"], encoding="ascii")
+      (cert_dir / "client.root.key").write_text(env["CRDB_CLIENT_ROOT_KEY"], encoding="ascii")
+      os.chmod(cert_dir / "client.root.key", 0o600)
+    os.chmod(cert_dir / "node.key", 0o600)
+  (root / "client-ca.crt").write_text(bundle[NODES[0]]["CRDB_CA_CRT"], encoding="ascii")
+
+
+def generate_bundle(root, regeneration_id=None):
+  plugin = make_deeploy_plugin()
+  allocation = {
+    "version": 1,
+    "service": "cockroachdb",
+    "status": "allocated",
+    "nodeOrder": list(NODES),
+    "clientTunnel": {"url": f"{HOSTNAME}:26257"},
+    "internalTunnels": [],
+  }
+  request = {
+    "target_nodes": list(NODES),
+    "pipeline_params": {"deeploy_cockroachdb": allocation},
+    "plugins": [
+      make_plugin_entry(
+        "CONTAINER_APP_RUNNER",
+        IMAGE=IMAGE,
+        ENV={
+          "CRDB_DATABASE": "appdb",
+          "CRDB_USER": "app_user",
+          "CRDB_PASSWORD": PASSWORD,
+        },
+      )
+    ],
+  }
+  if regeneration_id:
+    request["cockroachdb_certificate_regeneration_id"] = regeneration_id
+  inputs = make_inputs(**request)
+  plugin._prepare_cockroachdb_secure_config(inputs, NODES)
+  by_node = inputs["plugins"][0]["PER_NODE_CONFIG"]["byNode"]
+  bundle = {node: by_node[node]["ENV"] for node in NODES}
+  write_bundle(root, bundle)
+  cert = x509.load_pem_x509_certificate(bundle[NODES[0]]["CRDB_NODE_CRT"].encode("ascii"))
+  sans = cert.extensions.get_extension_for_class(x509.SubjectAlternativeName).value
+  if HOSTNAME not in sans.get_values_for_type(x509.DNSName):
+    raise AssertionError("Generated node certificate is missing the client DNS SAN")
+  return hashlib.sha256(bundle[NODES[0]]["CRDB_CA_CRT"].encode("ascii")).hexdigest()
+
+
+def start_node(root, index):
+  name = NODES[index]
+  alias = ALIASES[index]
+  docker("rm", "-f", name, check=False)
+  docker(
+    "run", "-d", "--name", name, "--hostname", alias,
+    "--network", NETWORK, "--network-alias", alias,
+    "-v", f"{root / f'certs-{index + 1}'}:/certs:ro",
+    "-v", f"verify_crdb_store_{index + 1}:/cockroach/cockroach-data",
+    "--entrypoint", "/cockroach/cockroach", IMAGE,
+    "start", "--certs-dir=/certs", "--store=/cockroach/cockroach-data",
+    "--listen-addr=0.0.0.0:26257", f"--advertise-addr={alias}:26257",
+    "--http-addr=0.0.0.0:8080", "--join=roach1:26257,roach2:26257,roach3:26257",
+    "--max-offset=2s", "--cache=.1", "--max-sql-memory=.1",
+  )
+
+
+def root_sql(sql, *, check=True):
+  return docker(
+    "exec", NODES[0], "/cockroach/cockroach", "sql", "--certs-dir=/certs",
+    "--host=roach1:26257", "--execute", sql, check=check, capture=True,
+  )
+
+
+def client_sql(sql, *, hostname=HOSTNAME, ca_path="/ca/client-ca.crt", sslmode="verify-full", password=PASSWORD, check=True):
+  uri = f"postgresql://app_user@{hostname}:26257/appdb?sslmode={sslmode}&sslrootcert={ca_path}"
+  return docker(
+    "exec", "-e", f"PGPASSWORD={password}", CLIENT,
+    "psql", "--set", "ON_ERROR_STOP=1", "--dbname", uri, "--command", sql,
+    check=check, capture=True,
+  )
+
+
+def wait_for(predicate, label, timeout=150):
+  deadline = time.monotonic() + timeout
+  last = None
+  while time.monotonic() < deadline:
+    try:
+      if predicate():
+        return
+    except Exception as exc:
+      last = exc
+    time.sleep(1)
+  raise RuntimeError(f"Timed out waiting for {label}: {last}")
+
+
+def cleanup(root):
+  docker("rm", "-f", CLIENT, RELAY, *NODES, check=False)
+  for index in range(1, 4):
+    docker("volume", "rm", "-f", f"verify_crdb_store_{index}", check=False)
+  shutil.rmtree(root, ignore_errors=True)
+
+
+def main():
+  root = Path(tempfile.mkdtemp(prefix="deeploy-crdb-verify-full-", dir="/tmp"))
+  try:
+    for service in ("deeploy_verify_node_1", "deeploy_verify_node_2", "deeploy_verify_node_3"):
+      state = docker("compose", "-f", "docker-compose/deeploy-crdb-verify-full.yaml", "ps", "-q", service, capture=True)
+      if not state.stdout.strip():
+        raise RuntimeError(f"Edge runtime {service} is not running")
+
+    first_fingerprint = generate_bundle(root)
+    for index in range(3):
+      start_node(root, index)
+
+    wait_for(
+      lambda: docker(
+        "exec", NODES[0], "/cockroach/cockroach", "init", "--certs-dir=/certs",
+        "--host=roach1:26257", check=False, capture=True, timeout=10,
+      ).returncode == 0 or root_sql("select 1", check=False).returncode == 0,
+      "cluster initialization",
+    )
+    wait_for(lambda: root_sql("select 1", check=False).returncode == 0, "initialized cluster")
+
+    root_sql(
+      "CREATE DATABASE IF NOT EXISTS appdb; "
+      "CREATE USER IF NOT EXISTS app_user WITH PASSWORD 'verify_full_disposable_password'; "
+      "GRANT ALL ON DATABASE appdb TO app_user; "
+      "CREATE TABLE IF NOT EXISTS appdb.verify_items (id INT PRIMARY KEY, note STRING); "
+      "GRANT ALL ON TABLE appdb.verify_items TO app_user; "
+      "UPSERT INTO appdb.verify_items SELECT i, 'persisted-' || i::STRING FROM generate_series(1, 1000) AS g(i);"
+    )
+
+    docker("run", "-d", "--name", RELAY, "--network", NETWORK,
+           "--network-alias", HOSTNAME, "--network-alias", "wrong-client.test",
+           "--cap-add", "NET_RAW", "--cap-add", "NET_ADMIN", "-v", f"{root}:/capture",
+           "--entrypoint", "socat", SNIFFER_IMAGE,
+           "TCP-LISTEN:26257,fork,reuseaddr", "TCP:roach1:26257")
+    docker("run", "-d", "--name", CLIENT, "--network", NETWORK,
+           "-v", f"{root}:/ca:ro", "--entrypoint", "sleep", CLIENT_IMAGE, "3600")
+    wait_for(lambda: client_sql("select 1", check=False).returncode == 0, "verify-full client")
+
+    if client_sql("select 1", hostname="wrong-client.test", check=False).returncode == 0:
+      raise AssertionError("verify-full accepted the wrong hostname")
+    if client_sql("select 1", sslmode="disable", check=False).returncode == 0:
+      raise AssertionError("server accepted plaintext SQL")
+    fake_bundle = make_deeploy_plugin()._generate_cockroachdb_cert_bundle(NODES, HOSTNAME)
+    (root / "wrong-ca.crt").write_text(fake_bundle[NODES[0]]["CRDB_CA_CRT"], encoding="ascii")
+    if client_sql("select 1", ca_path="/ca/wrong-ca.crt", check=False).returncode == 0:
+      raise AssertionError("verify-full accepted an unrelated CA")
+
+    canary = "VERIFY_FULL_SQL_CANARY_7f3e90"
+    capture = root / "tls.pcap"
+    sniffer = subprocess.Popen(
+      [
+        "docker", "exec", RELAY, "timeout", "-s", "INT", "8",
+        "tcpdump", "-U", "-i", "any", "-s", "0", "-w", "/capture/tls.pcap",
+        "tcp port 26257",
+      ],
+      stdout=subprocess.PIPE,
+      stderr=subprocess.PIPE,
+      text=True,
+    )
+    time.sleep(2)
+    client_sql(f"select '{canary}';")
+    _, sniffer_stderr = sniffer.communicate(timeout=15)
+    if sniffer.returncode not in (0, 124):
+      raise AssertionError(f"TLS packet capture failed: {sniffer_stderr.strip()}")
+    if not capture.exists() or capture.stat().st_size <= 24:
+      raise AssertionError("TLS packet capture contains no packets")
+    if canary.encode("ascii") in capture.read_bytes() or PASSWORD.encode("ascii") in capture.read_bytes():
+      raise AssertionError("TLS packet capture exposed SQL or password plaintext")
+
+    old_ca = root / "old-ca.crt"
+    shutil.copy2(root / "client-ca.crt", old_ca)
+    docker("stop", "--timeout", "20", *NODES)
+    second_fingerprint = generate_bundle(
+      root,
+      regeneration_id="22222222-2222-4222-8222-222222222222",
+    )
+    if first_fingerprint == second_fingerprint:
+      raise AssertionError("Certificate regeneration reused the CA")
+    start_node(root, 0)
+    start_node(root, 1)
+    wait_for(lambda: root_sql("select 1", check=False).returncode == 0, "rotated two-node quorum")
+    start_node(root, 2)
+    wait_for(lambda: "3" in root_sql("select count(*) from crdb_internal.gossip_nodes", check=False).stdout,
+             "delayed third-node convergence")
+    wait_for(lambda: client_sql("select count(*) from verify_items", check=False).returncode == 0,
+             "new-CA client")
+    if client_sql("select 1", ca_path="/ca/old-ca.crt", check=False).returncode == 0:
+      raise AssertionError("old CA remained trusted after full regeneration")
+    rows = client_sql("select count(*) from verify_items").stdout
+    if "1000" not in rows:
+      raise AssertionError(f"Expected 1000 persisted rows after rotation, got: {rows}")
+
+    print(
+      "verify-full workflow ok "
+      f"(nodes=3 rows=1000 ca_before={first_fingerprint[:12]} ca_after={second_fingerprint[:12]} capture_bytes={capture.stat().st_size})"
+    )
+  finally:
+    cleanup(root)
+
+
+if __name__ == "__main__":
+  main()

--- a/extensions/business/deeploy/deeploy_manager_api.py
+++ b/extensions/business/deeploy/deeploy_manager_api.py
@@ -98,6 +98,9 @@ class DeeployManagerApiPlugin(
       self.maybe_stop_tunnel_engine()
     self._init_request_tracking()
     self.__pending_deploy_requests = {}
+    self._cockroachdb_pending_regenerations = {}
+    self._cockroachdb_applied_regenerations = {}
+    self._cockroachdb_regeneration_lock = threading.Lock()
     self.__pipeline_persistence_queue = deque()
     self.__pipeline_persistence_lock = threading.Lock()
     self.__pipeline_persistence_event = threading.Event()
@@ -152,6 +155,12 @@ class DeeployManagerApiPlugin(
           )
 
         if ok:
+          self._mark_cockroachdb_regeneration_applied(
+            job.get('cockroachdb_regeneration_operation')
+          )
+          self._release_cockroachdb_regeneration(
+            job.get('cockroachdb_regeneration_claim_key')
+          )
           self.P(
             f"Persisted deployed pipeline metadata for job {job.get('job_id')}"
             f"{' (' + job.get('app_id') + ')' if job.get('app_id') else ''}."
@@ -160,6 +169,9 @@ class DeeployManagerApiPlugin(
 
         attempts = int(job.get('attempts', 0)) + 1
         if attempts >= 3:
+          self._release_cockroachdb_regeneration(
+            job.get('cockroachdb_regeneration_claim_key')
+          )
           self.P(
             f"Failed to persist deployed pipeline metadata for job {job.get('job_id')} after {attempts} attempts.",
             color='r'
@@ -219,6 +231,92 @@ class DeeployManagerApiPlugin(
       f"{' (' + persistence_state.get('app_id') + ')' if persistence_state.get('app_id') else ''}."
     )
     return True
+
+  def _claim_cockroachdb_regeneration(self, owner, app_id, regeneration_id, intent_hash):
+    if not regeneration_id:
+      return None
+    lock = getattr(self, "_cockroachdb_regeneration_lock", None)
+    if lock is None:
+      lock = threading.Lock()
+      self._cockroachdb_regeneration_lock = lock
+    with lock:
+      pending = getattr(self, "_cockroachdb_pending_regenerations", None)
+      if not isinstance(pending, dict):
+        pending = {}
+        self._cockroachdb_pending_regenerations = pending
+      key = (owner, app_id)
+      existing = pending.get(key)
+      if existing:
+        if existing == (regeneration_id, intent_hash):
+          raise ValueError("CockroachDB certificate regeneration is already in progress.")
+        raise ValueError("Another CockroachDB certificate regeneration is already in progress for this job.")
+      pending[key] = (regeneration_id, intent_hash)
+    return key
+
+  def _release_cockroachdb_regeneration(self, claim_key):
+    lock = getattr(self, "_cockroachdb_regeneration_lock", None)
+    if claim_key is not None and lock is not None:
+      with lock:
+        pending = getattr(self, "_cockroachdb_pending_regenerations", None)
+        if isinstance(pending, dict):
+          pending.pop(claim_key, None)
+    elif claim_key is not None:
+      pending = getattr(self, "_cockroachdb_pending_regenerations", None)
+      if isinstance(pending, dict):
+        pending.pop(claim_key, None)
+
+  def _get_cockroachdb_applied_regeneration(self, owner, app_id):
+    lock = getattr(self, "_cockroachdb_regeneration_lock", None)
+    if lock is None:
+      return None
+    with lock:
+      applied = getattr(self, "_cockroachdb_applied_regenerations", None)
+      return applied.get((owner, app_id)) if isinstance(applied, dict) else None
+
+  def _mark_cockroachdb_regeneration_applied(self, operation):
+    if not operation:
+      return
+    owner, app_id, regeneration_id, intent_hash = operation
+    lock = getattr(self, "_cockroachdb_regeneration_lock", None)
+    if lock is None:
+      lock = threading.Lock()
+      self._cockroachdb_regeneration_lock = lock
+    with lock:
+      applied = getattr(self, "_cockroachdb_applied_regenerations", None)
+      if not isinstance(applied, dict):
+        applied = {}
+        self._cockroachdb_applied_regenerations = applied
+      applied[(owner, app_id)] = (regeneration_id, intent_hash)
+
+  def _get_persisted_cockroachdb_deeploy_specs(self, job_id, owner, app_id):
+    pipeline = self.get_job_pipeline_from_cstore(
+      job_id,
+      timeout=30,
+      pin=False,
+      raise_on_error=False,
+      show_logs=False,
+    )
+    if not isinstance(pipeline, dict):
+      raise ValueError(
+        "CockroachDB certificate regeneration requires the persisted pipeline metadata."
+      )
+    pipeline_owner = pipeline.get(NetMonCt.OWNER.upper()) or pipeline.get(NetMonCt.OWNER)
+    pipeline_app_id = pipeline.get("NAME") or pipeline.get("name")
+    if str(pipeline_owner).lower() != str(owner).lower():
+      raise ValueError("Persisted CockroachDB pipeline owner does not match the update request.")
+    if str(pipeline_app_id).lower() != str(app_id).lower():
+      raise ValueError("Persisted CockroachDB pipeline app id does not match the update request.")
+    deeploy_specs = (
+      pipeline.get(NetMonCt.DEEPLOY_SPECS.upper())
+      or pipeline.get(NetMonCt.DEEPLOY_SPECS)
+    )
+    if not isinstance(deeploy_specs, dict):
+      raise ValueError(
+        "CockroachDB certificate regeneration requires persisted Deeploy specifications."
+      )
+    if str(deeploy_specs.get(DEEPLOY_KEYS.JOB_ID)).lower() != str(job_id).lower():
+      raise ValueError("Persisted CockroachDB pipeline job id does not match the update request.")
+    return deeploy_specs
 
 
   def on_request(self, request):
@@ -706,6 +804,8 @@ class DeeployManagerApiPlugin(
     dict
         The response dictionary
     """
+    regeneration_claim_key = None
+    keep_regeneration_claim = False
     try:
       self.__ensure_eth_balance()
       request_type = "create pipeline" if is_create else "update pipeline"
@@ -936,6 +1036,55 @@ class DeeployManagerApiPlugin(
           raise ValueError(msg)
         # TODO: Add check if jobType resources match the requested resources.
 
+        submitted_regeneration_id = self._get_cockroachdb_regeneration_id(inputs)
+        regeneration_specs = deeploy_specs_for_update
+        applied_operation = None
+        if submitted_regeneration_id:
+          applied_operation = self._get_cockroachdb_applied_regeneration(
+            auth_result[DEEPLOY_KEYS.ESCROW_OWNER], app_id
+          )
+          if applied_operation and applied_operation[0] == submitted_regeneration_id:
+            regeneration_specs = {}
+          else:
+            regeneration_specs = self._get_persisted_cockroachdb_deeploy_specs(
+              job_id,
+              auth_result[DEEPLOY_KEYS.ESCROW_OWNER],
+              app_id,
+            )
+        regeneration_id, regeneration_intent, already_applied = (
+          self._prepare_cockroachdb_regeneration_lifecycle(
+            inputs,
+            regeneration_specs,
+            applied_operation=applied_operation,
+          )
+        )
+        if already_applied:
+          return self._get_response({
+            DEEPLOY_KEYS.STATUS: DEEPLOY_STATUS.SUCCESS,
+            DEEPLOY_KEYS.STATUS_DETAILS: {
+              "cockroachdb_certificate_regeneration": "already_applied",
+            },
+            DEEPLOY_KEYS.APP_ID: app_id,
+            DEEPLOY_KEYS.REQUEST: {
+              DEEPLOY_KEYS.APP_ALIAS: app_alias,
+              DEEPLOY_KEYS.TARGET_NODES: deployment_targets,
+              DEEPLOY_KEYS.TARGET_NODES_COUNT: len(deployment_targets),
+              DEEPLOY_KEYS.JOB_APP_TYPE: job_app_type,
+            },
+            DEEPLOY_KEYS.AUTH: auth_result,
+          })
+        regeneration_claim_key = self._claim_cockroachdb_regeneration(
+          auth_result[DEEPLOY_KEYS.ESCROW_OWNER],
+          app_id,
+          regeneration_id,
+          regeneration_intent,
+        )
+        self._inherit_cockroachdb_certificates_from_discovered(
+          inputs,
+          discovered_plugin_instances,
+          deployment_targets,
+        )
+
         validated_nodes = self._check_nodes_availability(inputs)
         if set(validated_nodes) != set(deployment_targets):
           msg = (
@@ -952,6 +1101,15 @@ class DeeployManagerApiPlugin(
           job_app_type=job_app_type,
           dct_deeploy_specs=deeploy_specs_payload,
         )
+        if regeneration_id:
+          response_key_nodes = set(prepared_create_deploy_plan.get("response_keys") or {})
+          if (
+            not prepared_create_deploy_plan.get("enable_chainstore_response")
+            or response_key_nodes != set(validated_nodes)
+          ):
+            raise ValueError(
+              "CockroachDB certificate regeneration requires response keys for every target node."
+            )
         if prepared_create_deploy_plan.get("enable_chainstore_response"):
           self._reset_chainstore_response_keys(
             prepared_create_deploy_plan.get("response_keys", {}),
@@ -1089,7 +1247,15 @@ class DeeployManagerApiPlugin(
             'job_id': job_id,
           },
           'persistence': persistence_state,
+          'cockroachdb_regeneration_claim_key': regeneration_claim_key,
+          'cockroachdb_regeneration_operation': (
+            auth_result[DEEPLOY_KEYS.ESCROW_OWNER],
+            app_id,
+            regeneration_id,
+            regeneration_intent,
+          ) if regeneration_id else None,
         }
+        keep_regeneration_claim = regeneration_claim_key is not None
         return {'__pending__': pending_state}
 
       if str_status in [DEEPLOY_STATUS.SUCCESS, DEEPLOY_STATUS.COMMAND_DELIVERED]:
@@ -1120,10 +1286,13 @@ class DeeployManagerApiPlugin(
       }
 
       if self.cfg_deeploy_verbose > 1:
-        self.P(f"Request Result: {result}")
+        self.P(f"Request Result: status={str_status}, app_id={app_id}")
     except Exception as e:
       result = self.__handle_error(e, request)
     #endtry
+    finally:
+      if regeneration_claim_key is not None and not keep_regeneration_claim:
+        self._release_cockroachdb_regeneration(regeneration_claim_key)
     
     response = self._get_response({
       **result
@@ -1192,6 +1361,9 @@ class DeeployManagerApiPlugin(
           **pending.get('base_result', {})
         }
       self.__pending_deploy_requests.pop(pending_id, None)
+      self._release_cockroachdb_regeneration(
+        pending.get('cockroachdb_regeneration_claim_key')
+      )
       res = self._get_response({
         **result
       })
@@ -1238,9 +1410,44 @@ class DeeployManagerApiPlugin(
           self.P(f"An error occurred while submitting node update for job {job_id}: {e}", color='r')
     # endif nodes changed and success or delivered
 
-    if str_status in [DEEPLOY_STATUS.SUCCESS, DEEPLOY_STATUS.COMMAND_DELIVERED]:
-      self._queue_pipeline_persistence(pending.get('persistence'))
+    regeneration_operation = pending.get('cockroachdb_regeneration_operation')
+    persistence_state = pending.get('persistence')
+    if str_status == DEEPLOY_STATUS.SUCCESS and regeneration_operation:
+      persisted = False
+      if persistence_state:
+        for _ in range(3):
+          persisted = self.persist_job_pipeline_metadata(
+            pipeline=persistence_state['pipeline'],
+            job_id=persistence_state['job_id'],
+            previous_cid=persistence_state.get('previous_cid'),
+            delete_previous=persistence_state.get('delete_previous', False),
+          )
+          if persisted:
+            break
+      if not persisted:
+        if persistence_state:
+          persistence_state['cockroachdb_regeneration_operation'] = regeneration_operation
+          persistence_state['cockroachdb_regeneration_claim_key'] = pending.get(
+            'cockroachdb_regeneration_claim_key'
+          )
+        queued = self._queue_pipeline_persistence(persistence_state)
+        if not queued:
+          self._release_cockroachdb_regeneration(
+            pending.get('cockroachdb_regeneration_claim_key')
+          )
+        return {
+          DEEPLOY_KEYS.STATUS: DEEPLOY_STATUS.FAIL,
+          DEEPLOY_KEYS.ERROR: "CockroachDB certificate regeneration succeeded but metadata persistence failed.",
+          DEEPLOY_KEYS.STATUS_DETAILS: dct_status,
+          **pending.get('base_result', {})
+        }
+      self._mark_cockroachdb_regeneration_applied(regeneration_operation)
+    elif str_status in [DEEPLOY_STATUS.SUCCESS, DEEPLOY_STATUS.COMMAND_DELIVERED]:
+      self._queue_pipeline_persistence(persistence_state)
 
+    self._release_cockroachdb_regeneration(
+      pending.get('cockroachdb_regeneration_claim_key')
+    )
     return {
       DEEPLOY_KEYS.STATUS: str_status,
       DEEPLOY_KEYS.STATUS_DETAILS: dct_status,
@@ -1549,6 +1756,10 @@ class DeeployManagerApiPlugin(
       pipeline_params : dict, optional
           Additional pipeline-level parameters forwarded to the data capture thread. `null` falls back to `{}`.
           The provided keys are merged into the pipeline configuration at the top level.
+
+      cockroachdb_certificate_regeneration_id : str, optional
+          UUIDv4 operation id for an explicit full-fleet CockroachDB TLS certificate regeneration.
+          Valid only for CockroachDB service updates with all-node response confirmation enabled.
 
       nonce : str
           The nonce used for signing the request

--- a/extensions/business/deeploy/deeploy_mixin.py
+++ b/extensions/business/deeploy/deeploy_mixin.py
@@ -1,7 +1,9 @@
 import copy
+import hashlib
 import json
 import ipaddress
 import re
+from urllib.parse import urlsplit
 from datetime import datetime, timezone
 from datetime import timedelta
 from decimal import Decimal, InvalidOperation
@@ -104,6 +106,18 @@ COCKROACHDB_REQUIRED_AUTH_ENV_KEYS = (
   "CRDB_DATABASE",
   "CRDB_USER",
   "CRDB_PASSWORD",
+)
+COCKROACHDB_ALLOCATION_PARAM = "deeploy_cockroachdb"
+COCKROACHDB_CERT_REGENERATION_REQUEST_KEY = "cockroachdb_certificate_regeneration_id"
+COCKROACHDB_CERT_HOSTNAME_KEY = "certificateHostname"
+COCKROACHDB_CERT_GENERATION_ID_KEY = "certificateGenerationId"
+COCKROACHDB_CERT_CA_SHA256_KEY = "certificateCaSha256"
+COCKROACHDB_CERT_REGENERATION_INTENT_KEY = "certificateRegenerationIntentSha256"
+COCKROACHDB_CERT_LIFECYCLE_KEYS = (
+  COCKROACHDB_CERT_HOSTNAME_KEY,
+  COCKROACHDB_CERT_GENERATION_ID_KEY,
+  COCKROACHDB_CERT_CA_SHA256_KEY,
+  COCKROACHDB_CERT_REGENERATION_INTENT_KEY,
 )
 
 class _DeeployMixin:
@@ -3437,6 +3451,7 @@ class _DeeployMixin:
     if not isinstance(raw_config, dict):
       return False
     try:
+      common_ca = None
       for index, node in enumerate(target_nodes):
         overlay = self._overlay_for_node(raw_config, node, index)
         env = overlay.get("ENV")
@@ -3445,6 +3460,10 @@ class _DeeployMixin:
         for key in COCKROACHDB_CERT_ENV_KEYS:
           if not isinstance(env.get(key), str) or "-----BEGIN" not in env.get(key):
             return False
+        if common_ca is None:
+          common_ca = env["CRDB_CA_CRT"]
+        elif env["CRDB_CA_CRT"] != common_ca:
+          return False
         if index == 0:
           for key in COCKROACHDB_BOOTSTRAP_CERT_ENV_KEYS:
             if not isinstance(env.get(key), str) or "-----BEGIN" not in env.get(key):
@@ -3452,6 +3471,201 @@ class _DeeployMixin:
     except Exception:
       return False
     return True
+
+  def _inherit_cockroachdb_certificates_from_discovered(
+    self,
+    inputs,
+    discovered_plugin_instances,
+    target_nodes,
+  ):
+    plugins = inputs.get(DEEPLOY_KEYS.PLUGINS)
+    if not isinstance(plugins, list) or not isinstance(discovered_plugin_instances, list):
+      return inputs
+    cert_keys = (*COCKROACHDB_CERT_ENV_KEYS, *COCKROACHDB_BOOTSTRAP_CERT_ENV_KEYS)
+
+    for plugin_instance in plugins:
+      if not self._is_cockroachdb_plugin_instance(plugin_instance):
+        continue
+      instance_id = plugin_instance.get(DEEPLOY_KEYS.PLUGIN_INSTANCE_ID)
+      if not instance_id:
+        continue
+      self._canonicalize_per_node_config_key(plugin_instance)
+      raw_config = plugin_instance.get(CANONICAL_PER_NODE_CONFIG_KEY)
+      by_node = {}
+      for index, node in enumerate(target_nodes or []):
+        overlay = self._overlay_for_node(raw_config, node, index) if raw_config else {}
+        overlay = self.deepcopy(overlay) if isinstance(overlay, dict) else {}
+        overlay_env = overlay.get("ENV")
+        overlay_env = self.deepcopy(overlay_env) if isinstance(overlay_env, dict) else {}
+
+        for discovered in discovered_plugin_instances:
+          if discovered.get(DEEPLOY_PLUGIN_DATA.INSTANCE_ID) != instance_id:
+            continue
+          runtime = discovered.get(DEEPLOY_PLUGIN_DATA.PLUGIN_INSTANCE, {})
+          runtime_config = runtime.get("instance_conf", {}) if isinstance(runtime, dict) else {}
+          runtime_raw_config = (
+            runtime_config.get(CANONICAL_PER_NODE_CONFIG_KEY)
+            or runtime_config.get("perNodeConfig")
+          ) if isinstance(runtime_config, dict) else None
+          discovered_node = discovered.get(DEEPLOY_PLUGIN_DATA.NODE)
+          if discovered_node != node and not isinstance(runtime_raw_config, dict):
+            continue
+          runtime_envs = []
+          direct_env = runtime_config.get("ENV") if isinstance(runtime_config, dict) else None
+          if discovered_node == node and isinstance(direct_env, dict):
+            runtime_envs.append(direct_env)
+          runtime_overlay = (
+            self._overlay_for_node(runtime_raw_config, node, index)
+            if isinstance(runtime_raw_config, dict) else {}
+          )
+          per_node_env = runtime_overlay.get("ENV") if isinstance(runtime_overlay, dict) else None
+          if isinstance(per_node_env, dict):
+            runtime_envs.append(per_node_env)
+          for runtime_env in runtime_envs:
+            for key in cert_keys:
+              if isinstance(runtime_env.get(key), str):
+                overlay_env[key] = runtime_env[key]
+
+        overlay["ENV"] = overlay_env
+        by_node[node] = overlay
+      plugin_instance[CANONICAL_PER_NODE_CONFIG_KEY] = {"byNode": by_node}
+    return inputs
+
+  def _cockroachdb_client_hostname(self, endpoint):
+    if not isinstance(endpoint, str) or not endpoint.strip():
+      raise ValueError("CockroachDB client tunnel endpoint is missing.")
+    value = endpoint.strip()
+    parsed = urlsplit(value if "://" in value else f"//{value}")
+    if "://" in value and parsed.scheme.lower() != "tcp":
+      raise ValueError("CockroachDB client tunnel endpoint must use the tcp scheme.")
+    if parsed.username or parsed.password:
+      raise ValueError("CockroachDB client tunnel endpoint must not include credentials.")
+    if parsed.path not in ("", "/") or parsed.query or parsed.fragment:
+      raise ValueError("CockroachDB client tunnel endpoint must not include a path, query, or fragment.")
+    try:
+      parsed.port
+    except ValueError as exc:
+      raise ValueError("CockroachDB client tunnel endpoint contains an invalid port.") from exc
+    hostname = parsed.hostname
+    if not hostname or "*" in hostname:
+      raise ValueError("CockroachDB client tunnel endpoint must contain an exact hostname or IP address.")
+    hostname = hostname.rstrip(".").lower()
+    try:
+      ipaddress.ip_address(hostname)
+      return hostname
+    except ValueError:
+      pass
+    if len(hostname) > 253:
+      raise ValueError("CockroachDB client tunnel hostname is too long.")
+    labels = hostname.split(".")
+    if any(
+      not label
+      or len(label) > 63
+      or not re.fullmatch(r"[a-z0-9](?:[a-z0-9-]*[a-z0-9])?", label)
+      for label in labels
+    ):
+      raise ValueError("CockroachDB client tunnel endpoint contains an invalid hostname.")
+    return hostname
+
+  def _get_cockroachdb_allocation(self, inputs, required=True):
+    pipeline_params = self._extract_pipeline_params(inputs)
+    allocation = pipeline_params.get(COCKROACHDB_ALLOCATION_PARAM)
+    if not isinstance(allocation, dict):
+      if not required:
+        return None, None
+      raise ValueError("CockroachDB client tunnel allocation is missing.")
+    client_tunnel = allocation.get("clientTunnel")
+    if not isinstance(client_tunnel, dict):
+      if not required:
+        return allocation, None
+      raise ValueError("CockroachDB client tunnel allocation is missing.")
+    endpoint = client_tunnel.get("url")
+    if not endpoint and not required:
+      return allocation, None
+    hostname = self._cockroachdb_client_hostname(endpoint)
+    return allocation, hostname
+
+  def _get_cockroachdb_regeneration_id(self, inputs):
+    value = inputs.get(COCKROACHDB_CERT_REGENERATION_REQUEST_KEY)
+    if value is None:
+      return None
+    if not isinstance(value, str) or not re.fullmatch(
+      r"[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}",
+      value,
+      flags=re.IGNORECASE,
+    ):
+      raise ValueError("CockroachDB certificate regeneration id must be a UUIDv4 string.")
+    return value.lower()
+
+  def _get_cockroachdb_allocation_from_specs(self, deeploy_specs):
+    pipeline_params = self._get_pipeline_params_from_deeploy_specs(deeploy_specs)
+    allocation = pipeline_params.get(COCKROACHDB_ALLOCATION_PARAM)
+    return allocation if isinstance(allocation, dict) else None
+
+  def _cockroachdb_regeneration_intent_hash(self, inputs):
+    payload = self.deepcopy(dict(inputs))
+    for key in (*DEEPLOY_V3_HASH_EXCLUDED_KEYS, DEEPLOY_KEYS.NONCE, COCKROACHDB_CERT_REGENERATION_REQUEST_KEY):
+      payload.pop(key, None)
+    pipeline_params = payload.get(DEEPLOY_KEYS.PIPELINE_PARAMS)
+    allocation = (
+      pipeline_params.get(COCKROACHDB_ALLOCATION_PARAM)
+      if isinstance(pipeline_params, dict) else None
+    )
+    if isinstance(allocation, dict):
+      for key in (*COCKROACHDB_CERT_LIFECYCLE_KEYS, "updatedAt"):
+        allocation.pop(key, None)
+    return compact_canonical_sha256(payload)
+
+  def _prepare_cockroachdb_regeneration_lifecycle(
+    self,
+    inputs,
+    deeploy_specs,
+    applied_operation=None,
+  ):
+    if not self._request_has_cockroachdb_plugin(inputs):
+      return None, None, False
+
+    regeneration_id = self._get_cockroachdb_regeneration_id(inputs)
+    allocation, _ = self._get_cockroachdb_allocation(
+      inputs,
+      required=bool(regeneration_id),
+    )
+    current_allocation = self._get_cockroachdb_allocation_from_specs(deeploy_specs)
+    if isinstance(allocation, dict) and isinstance(current_allocation, dict):
+      for key in COCKROACHDB_CERT_LIFECYCLE_KEYS:
+        if key in current_allocation:
+          allocation[key] = self.deepcopy(current_allocation[key])
+        else:
+          allocation.pop(key, None)
+
+    if not regeneration_id:
+      return None, None, False
+
+    if not bool(inputs.get(DEEPLOY_KEYS.CHAINSTORE_RESPONSE, False)):
+      raise ValueError(
+        "CockroachDB certificate regeneration requires all-node response confirmation."
+      )
+    intent_hash = self._cockroachdb_regeneration_intent_hash(inputs)
+    if applied_operation:
+      applied_id, applied_intent = applied_operation
+      if applied_id == regeneration_id:
+        if applied_intent != intent_hash:
+          raise ValueError(
+            "CockroachDB certificate regeneration id was already applied to a different update intent."
+          )
+        return regeneration_id, intent_hash, True
+    if isinstance(current_allocation, dict) and current_allocation.get(
+      COCKROACHDB_CERT_GENERATION_ID_KEY
+    ) == regeneration_id:
+      current_intent = current_allocation.get(COCKROACHDB_CERT_REGENERATION_INTENT_KEY)
+      if current_intent != intent_hash:
+        raise ValueError(
+          "CockroachDB certificate regeneration id was already applied to a different update intent."
+        )
+      return regeneration_id, intent_hash, True
+
+    allocation[COCKROACHDB_CERT_REGENERATION_INTENT_KEY] = intent_hash
+    return regeneration_id, intent_hash, False
 
   def _pem_private_key(self, key):
     from cryptography.hazmat.primitives import serialization
@@ -3473,7 +3687,7 @@ class _DeeployMixin:
       x509.NameAttribute(NameOID.COMMON_NAME, value),
     ])
 
-  def _generate_cockroachdb_cert_bundle(self, target_nodes):
+  def _generate_cockroachdb_cert_bundle(self, target_nodes, client_hostname=None):
     """
     Generate a temporary CA and per-node CockroachDB certificates.
 
@@ -3524,6 +3738,14 @@ class _DeeployMixin:
     roach_names = [f"roach{i}" for i in range(1, len(target_nodes) + 1)]
     dns_sans = [*roach_names, "localhost"]
     ip_sans = ["127.0.0.1"]
+    if client_hostname:
+      try:
+        ipaddress.ip_address(client_hostname)
+        if client_hostname not in ip_sans:
+          ip_sans.append(client_hostname)
+      except ValueError:
+        if client_hostname not in dns_sans:
+          dns_sans.append(client_hostname)
 
     def build_signed_cert(common_name, public_key, san_dns=None, san_ips=None, client=False, server=False):
       san_items = []
@@ -3589,17 +3811,46 @@ class _DeeployMixin:
     if not target_nodes:
       return inputs
 
-    for plugin_instance in plugins_array:
-      if not self._is_cockroachdb_plugin_instance(plugin_instance):
-        continue
+    cockroachdb_plugins = [
+      plugin_instance for plugin_instance in plugins_array
+      if self._is_cockroachdb_plugin_instance(plugin_instance)
+    ]
+    if not cockroachdb_plugins:
+      return inputs
+
+    regeneration_id = self._get_cockroachdb_regeneration_id(inputs)
+    for plugin_instance in cockroachdb_plugins:
+      self._validate_cockroachdb_auth_env(plugin_instance.get("ENV"))
+    allocation, client_hostname = self._get_cockroachdb_allocation(
+      inputs,
+      required=bool(regeneration_id),
+    )
+    managed_hostname = (
+      allocation.get(COCKROACHDB_CERT_HOSTNAME_KEY)
+      if isinstance(allocation, dict) else None
+    )
+    hostname_changed = bool(
+      client_hostname
+      and isinstance(managed_hostname, str)
+      and managed_hostname != client_hostname
+    )
+
+    for plugin_instance in cockroachdb_plugins:
       env = plugin_instance.setdefault("ENV", {})
-      self._validate_cockroachdb_auth_env(env)
       env["CRDB_SECURE"] = "true"
 
       self._canonicalize_per_node_config_key(plugin_instance)
       raw_config = plugin_instance.get(CANONICAL_PER_NODE_CONFIG_KEY)
       existing_complete = self._cockroachdb_cert_bundle_complete(plugin_instance, target_nodes)
-      cert_bundle = None if existing_complete else self._generate_cockroachdb_cert_bundle(target_nodes)
+      regeneration_pending = bool(
+        regeneration_id
+        and allocation.get(COCKROACHDB_CERT_GENERATION_ID_KEY) != regeneration_id
+      )
+      must_generate = not existing_complete or hostname_changed or regeneration_pending
+      cert_bundle = (
+        self._generate_cockroachdb_cert_bundle(target_nodes, client_hostname)
+        if must_generate else None
+      )
 
       by_node = {}
       for index, node in enumerate(target_nodes):
@@ -3615,6 +3866,24 @@ class _DeeployMixin:
         overlay["ENV"] = overlay_env
         by_node[node] = overlay
       plugin_instance[CANONICAL_PER_NODE_CONFIG_KEY] = {"byNode": by_node}
+
+      if (
+        isinstance(allocation, dict)
+        and client_hostname
+        and (cert_bundle is not None or managed_hostname == client_hostname)
+      ):
+        allocation[COCKROACHDB_CERT_HOSTNAME_KEY] = client_hostname
+      if isinstance(allocation, dict) and cert_bundle is not None:
+        ca_crt = cert_bundle[target_nodes[0]]["CRDB_CA_CRT"]
+        allocation[COCKROACHDB_CERT_CA_SHA256_KEY] = hashlib.sha256(
+          ca_crt.encode("ascii")
+        ).hexdigest()
+      if isinstance(allocation, dict) and cert_bundle is not None:
+        if regeneration_id:
+          allocation[COCKROACHDB_CERT_GENERATION_ID_KEY] = regeneration_id
+        else:
+          allocation.pop(COCKROACHDB_CERT_GENERATION_ID_KEY, None)
+          allocation.pop(COCKROACHDB_CERT_REGENERATION_INTENT_KEY, None)
 
     return inputs
 
@@ -3647,7 +3916,16 @@ class _DeeployMixin:
     if len(target_nodes) < 2:
       raise ValueError("CockroachDB requires at least 2 target nodes.")
 
-    cert_bundle = self._generate_cockroachdb_cert_bundle(target_nodes)
+    pipeline_params = pipeline.get("pipeline_params")
+    allocation = (
+      pipeline_params.get(COCKROACHDB_ALLOCATION_PARAM)
+      if isinstance(pipeline_params, dict) else None
+    )
+    client_tunnel = allocation.get("clientTunnel") if isinstance(allocation, dict) else None
+    client_hostname = None
+    if isinstance(client_tunnel, dict) and client_tunnel.get("url"):
+      client_hostname = self._cockroachdb_client_hostname(client_tunnel.get("url"))
+    cert_bundle = self._generate_cockroachdb_cert_bundle(target_nodes, client_hostname)
     for plugin in plugins:
       if not isinstance(plugin, dict):
         continue

--- a/extensions/business/deeploy/tests/test_create_requests.py
+++ b/extensions/business/deeploy/tests/test_create_requests.py
@@ -1,7 +1,11 @@
 import unittest
+import copy
 from collections import defaultdict
+import ipaddress
 import sys
 import types
+
+from cryptography import x509
 
 
 for _mod_name in ("torch", "torch.nn", "torch.nn.functional"):
@@ -28,6 +32,176 @@ class _KeyErrorOnMissingAttrInputs(dict):
 
 
 class DeeployCreateRequestPreparationTests(unittest.TestCase):
+
+  def _make_cockroachdb_secure_inputs(self, client_url="tcp.ratio1.link:30472"):
+    return make_inputs(
+      pipeline_params={
+        "deeploy_cockroachdb": {
+          "version": 1,
+          "service": "cockroachdb",
+          "status": "allocated",
+          "nodeOrder": ["0xai_node_a", "0xai_node_b"],
+          "clientTunnel": {"url": client_url},
+          "internalTunnels": [],
+        },
+      },
+      plugins=[
+        make_plugin_entry(
+          "CONTAINER_APP_RUNNER",
+          plugin_name="cockroachdb",
+          IMAGE="ghcr.io/ratio1/deeploy-cockroachdb-service:main",
+          ENV={
+            "CRDB_DATABASE": "appdb",
+            "CRDB_USER": "app_user",
+            "CRDB_PASSWORD": "secret-password",
+          },
+          PER_NODE_CONFIG={
+            "byNode": {
+              "0xai_node_a": {"ENV": {"CRDB_NODE_ID": "1", "CF_TUNNEL_TOKEN": "token-a"}},
+              "0xai_node_b": {"ENV": {"CRDB_NODE_ID": "2", "CF_TUNNEL_TOKEN": "token-b"}},
+            },
+          },
+        ),
+      ],
+    )
+
+  def test_cockroachdb_client_hostname_parser_accepts_tunnel_endpoint_forms(self):
+    plugin = make_deeploy_plugin()
+
+    self.assertEqual(
+      plugin._cockroachdb_client_hostname("tcp.ratio1.link:30472"),
+      "tcp.ratio1.link",
+    )
+    self.assertEqual(
+      plugin._cockroachdb_client_hostname("tcp://db.example.test:26257"),
+      "db.example.test",
+    )
+    self.assertEqual(plugin._cockroachdb_client_hostname("127.0.0.2:26257"), "127.0.0.2")
+
+    for invalid in (
+      "",
+      "tcp://user:password@db.example.test:26257",
+      "tcp://*.example.test:26257",
+      "tcp://db.example.test:26257/path",
+      "tcp://db.example.test:26257?query=value",
+      "tcp://db.example.test:not-a-port",
+      "tcp://db.example.test:70000",
+    ):
+      with self.subTest(invalid=invalid):
+        with self.assertRaisesRegex(ValueError, "client tunnel"):
+          plugin._cockroachdb_client_hostname(invalid)
+
+  def test_generated_cockroachdb_node_certificates_include_client_hostname(self):
+    plugin = make_deeploy_plugin()
+
+    bundle = plugin._generate_cockroachdb_cert_bundle(
+      ["0xai_node_a", "0xai_node_b"],
+      client_hostname="tcp.ratio1.link",
+    )
+
+    for node in ("0xai_node_a", "0xai_node_b"):
+      cert = x509.load_pem_x509_certificate(bundle[node]["CRDB_NODE_CRT"].encode("ascii"))
+      san = cert.extensions.get_extension_for_class(x509.SubjectAlternativeName).value
+      self.assertIn("tcp.ratio1.link", san.get_values_for_type(x509.DNSName))
+      self.assertIn("roach1", san.get_values_for_type(x509.DNSName))
+      self.assertIn("roach2", san.get_values_for_type(x509.DNSName))
+      self.assertIn("localhost", san.get_values_for_type(x509.DNSName))
+
+    ip_bundle = plugin._generate_cockroachdb_cert_bundle(
+      ["0xai_node_a", "0xai_node_b"],
+      client_hostname="127.0.0.2",
+    )
+    ip_cert = x509.load_pem_x509_certificate(ip_bundle["0xai_node_a"]["CRDB_NODE_CRT"].encode("ascii"))
+    ip_san = ip_cert.extensions.get_extension_for_class(x509.SubjectAlternativeName).value
+    self.assertIn(ipaddress.ip_address("127.0.0.2"), ip_san.get_values_for_type(x509.IPAddress))
+
+  def test_cockroachdb_secure_config_reuses_hostname_bound_bundle_and_forces_one_generation(self):
+    plugin = make_deeploy_plugin()
+    inputs = self._make_cockroachdb_secure_inputs()
+    nodes = ["0xai_node_a", "0xai_node_b"]
+
+    plugin._prepare_cockroachdb_secure_config(inputs, nodes)
+    allocation = inputs[DEEPLOY_KEYS.PIPELINE_PARAMS]["deeploy_cockroachdb"]
+    first_key = inputs[DEEPLOY_KEYS.PLUGINS][0]["PER_NODE_CONFIG"]["byNode"][nodes[0]]["ENV"]["CRDB_NODE_KEY"]
+    self.assertEqual(allocation["certificateHostname"], "tcp.ratio1.link")
+
+    plugin._prepare_cockroachdb_secure_config(inputs, nodes)
+    reused_key = inputs[DEEPLOY_KEYS.PLUGINS][0]["PER_NODE_CONFIG"]["byNode"][nodes[0]]["ENV"]["CRDB_NODE_KEY"]
+    self.assertEqual(reused_key, first_key)
+
+    inputs["cockroachdb_certificate_regeneration_id"] = "11111111-1111-4111-8111-111111111111"
+    plugin._prepare_cockroachdb_secure_config(inputs, nodes)
+    regenerated_key = inputs[DEEPLOY_KEYS.PLUGINS][0]["PER_NODE_CONFIG"]["byNode"][nodes[0]]["ENV"]["CRDB_NODE_KEY"]
+    self.assertNotEqual(regenerated_key, first_key)
+    self.assertEqual(
+      allocation["certificateGenerationId"],
+      "11111111-1111-4111-8111-111111111111",
+    )
+
+    plugin._prepare_cockroachdb_secure_config(inputs, nodes)
+    replay_key = inputs[DEEPLOY_KEYS.PLUGINS][0]["PER_NODE_CONFIG"]["byNode"][nodes[0]]["ENV"]["CRDB_NODE_KEY"]
+    self.assertEqual(replay_key, regenerated_key)
+
+    inputs.pop("cockroachdb_certificate_regeneration_id")
+    allocation["clientTunnel"]["url"] = "replacement.example.test:26257"
+    plugin._prepare_cockroachdb_secure_config(inputs, nodes)
+    self.assertNotIn("certificateGenerationId", allocation)
+    self.assertNotIn("certificateRegenerationIntentSha256", allocation)
+
+  def test_cockroachdb_secure_config_regenerates_when_managed_hostname_changes(self):
+    plugin = make_deeploy_plugin()
+    inputs = self._make_cockroachdb_secure_inputs("old.example.test:26257")
+    nodes = ["0xai_node_a", "0xai_node_b"]
+
+    plugin._prepare_cockroachdb_secure_config(inputs, nodes)
+    first_key = inputs[DEEPLOY_KEYS.PLUGINS][0]["PER_NODE_CONFIG"]["byNode"][nodes[0]]["ENV"]["CRDB_NODE_KEY"]
+    allocation = inputs[DEEPLOY_KEYS.PIPELINE_PARAMS]["deeploy_cockroachdb"]
+    allocation["clientTunnel"]["url"] = "new.example.test:26257"
+
+    plugin._prepare_cockroachdb_secure_config(inputs, nodes)
+
+    second_key = inputs[DEEPLOY_KEYS.PLUGINS][0]["PER_NODE_CONFIG"]["byNode"][nodes[0]]["ENV"]["CRDB_NODE_KEY"]
+    self.assertNotEqual(second_key, first_key)
+    self.assertEqual(allocation["certificateHostname"], "new.example.test")
+
+  def test_cockroachdb_regeneration_ignores_request_supplied_lifecycle_metadata(self):
+    plugin = make_deeploy_plugin()
+    inputs = self._make_cockroachdb_secure_inputs()
+    nodes = ["0xai_node_a", "0xai_node_b"]
+    plugin._prepare_cockroachdb_secure_config(inputs, nodes)
+    original_key = inputs[DEEPLOY_KEYS.PLUGINS][0]["PER_NODE_CONFIG"]["byNode"][nodes[0]]["ENV"][
+      "CRDB_NODE_KEY"
+    ]
+    allocation = inputs[DEEPLOY_KEYS.PIPELINE_PARAMS]["deeploy_cockroachdb"]
+    persisted_allocation = copy.deepcopy(allocation)
+    persisted_allocation["certificateGenerationId"] = "11111111-1111-4111-8111-111111111111"
+    persisted_allocation["certificateRegenerationIntentSha256"] = "old-intent"
+    new_id = "22222222-2222-4222-8222-222222222222"
+    allocation["certificateGenerationId"] = new_id
+    allocation["certificateRegenerationIntentSha256"] = "caller-controlled"
+    inputs["cockroachdb_certificate_regeneration_id"] = new_id
+    inputs[DEEPLOY_KEYS.CHAINSTORE_RESPONSE] = True
+
+    plugin._prepare_cockroachdb_regeneration_lifecycle(
+      inputs,
+      {
+        DEEPLOY_KEYS.JOB_CONFIG: {
+          DEEPLOY_KEYS.PIPELINE_PARAMS: {"deeploy_cockroachdb": persisted_allocation},
+        },
+      },
+    )
+    self.assertEqual(
+      allocation["certificateGenerationId"],
+      "11111111-1111-4111-8111-111111111111",
+    )
+
+    plugin._prepare_cockroachdb_secure_config(inputs, nodes)
+
+    regenerated_key = inputs[DEEPLOY_KEYS.PLUGINS][0]["PER_NODE_CONFIG"]["byNode"][nodes[0]]["ENV"][
+      "CRDB_NODE_KEY"
+    ]
+    self.assertNotEqual(regenerated_key, original_key)
+    self.assertEqual(allocation["certificateGenerationId"], new_id)
 
   def test_prepare_single_plugin_instance_uses_signature_and_app_params(self):
     plugin = make_deeploy_plugin()

--- a/extensions/business/deeploy/tests/test_update_requests.py
+++ b/extensions/business/deeploy/tests/test_update_requests.py
@@ -70,7 +70,7 @@ class DeeployUpdateRequestPreparationTests(unittest.TestCase):
       DEEPLOY_KEYS.ESCROW_OWNER: "0xOwner",
     }
     plugin.deeploy_check_payment_and_job_owner = lambda *args, **kwargs: True
-    plugin._extract_pipeline_params = lambda inputs: {}
+    plugin._extract_pipeline_params = lambda inputs: inputs.get(DEEPLOY_KEYS.PIPELINE_PARAMS, {})
     plugin._check_and_maybe_convert_address = lambda node: node
     plugin._gather_running_pipeline_context = lambda **kwargs: {
       "discovered_instances": discovered_instances,
@@ -78,9 +78,21 @@ class DeeployUpdateRequestPreparationTests(unittest.TestCase):
       "deeploy_specs": deeploy_specs or {"job_id": 11},
     }
     plugin._get_pipeline_from_cstore = lambda job_id: None
+    plugin.get_job_pipeline_from_cstore = lambda job_id, **kwargs: {
+      "OWNER": "0xOwner",
+      "NAME": "cockroachdb_422ce92",
+      "DEEPLOY_SPECS": copy.deepcopy(deeploy_specs or {"job_id": 11}),
+    }
     plugin._check_nodes_availability = lambda inputs: nodes or ["node-1"]
 
-    called = {"delete": 0, "deploy": 0, "deploy_kwargs": None, "queued": 0, "bc_update": 0}
+    called = {
+      "delete": 0,
+      "deploy": 0,
+      "deploy_kwargs": None,
+      "queued": 0,
+      "persisted": 0,
+      "bc_update": 0,
+    }
     plugin.bc = types.SimpleNamespace(
       node_addr_to_eth_addr=lambda node: node,
       submit_node_update=lambda **kwargs: called.__setitem__("bc_update", called["bc_update"] + 1),
@@ -94,7 +106,12 @@ class DeeployUpdateRequestPreparationTests(unittest.TestCase):
 
     plugin.check_and_deploy_pipelines = check_and_deploy_pipelines
     plugin._build_pipeline_persistence_state = lambda **kwargs: {"state": kwargs}
-    plugin._queue_pipeline_persistence = lambda state: called.__setitem__("queued", called["queued"] + 1)
+    plugin._queue_pipeline_persistence = (
+      lambda state: called.__setitem__("queued", called["queued"] + 1) or True
+    )
+    plugin.persist_job_pipeline_metadata = (
+      lambda **kwargs: called.__setitem__("persisted", called["persisted"] + 1) or True
+    )
     return plugin, called
 
   def _make_four_replica_cockroach_update_fixture(self, plugin):
@@ -366,6 +383,426 @@ class DeeployUpdateRequestPreparationTests(unittest.TestCase):
       self.assertEqual(instance["PER_NODE_TARGET_NODES"], nodes)
       self.assertEqual(instance["CONTAINER_RESOURCES"]["storage"], "0g")
       self.assertEqual(instance["FIXED_SIZE_VOLUMES"]["cockroach_data"]["SIZE"], "8G")
+
+  def test_process_cockroachdb_regeneration_replay_is_noop_and_intent_bound(self):
+    fixture_plugin = make_deeploy_plugin()
+    nodes, discovered_instances, request_plugin = self._make_four_replica_cockroach_update_fixture(fixture_plugin)
+    regeneration_id = "11111111-1111-4111-8111-111111111111"
+    allocation = {
+      "version": 1,
+      "service": "cockroachdb",
+      "status": "allocated",
+      "nodeOrder": nodes,
+      "clientTunnel": {"url": "crdb-client.test:26257"},
+      "internalTunnels": [],
+    }
+    request = {
+      DEEPLOY_KEYS.APP_ID: "cockroachdb_422ce92",
+      DEEPLOY_KEYS.APP_ALIAS: "cockroachdb",
+      DEEPLOY_KEYS.JOB_ID: 11,
+      DEEPLOY_KEYS.JOB_APP_TYPE: JOB_APP_TYPES.SERVICE,
+      DEEPLOY_KEYS.PIPELINE_INPUT_TYPE: "void",
+      DEEPLOY_KEYS.CHAINSTORE_RESPONSE: True,
+      DEEPLOY_KEYS.TARGET_NODES: nodes,
+      DEEPLOY_KEYS.TARGET_NODES_COUNT: len(nodes),
+      DEEPLOY_KEYS.PIPELINE_PARAMS: {"deeploy_cockroachdb": allocation},
+      DEEPLOY_KEYS.PLUGINS: [request_plugin],
+      "cockroachdb_certificate_regeneration_id": regeneration_id,
+    }
+    intent_hash = fixture_plugin._cockroachdb_regeneration_intent_hash(make_inputs(**request))
+    persisted_allocation = copy.deepcopy(allocation)
+    persisted_allocation.update({
+      "certificateGenerationId": regeneration_id,
+      "certificateRegenerationIntentSha256": intent_hash,
+    })
+    deeploy_specs = {
+      DEEPLOY_KEYS.JOB_ID: 11,
+      DEEPLOY_KEYS.JOB_APP_TYPE: JOB_APP_TYPES.SERVICE,
+      DEEPLOY_KEYS.CURRENT_TARGET_NODES: nodes,
+      DEEPLOY_KEYS.JOB_CONFIG: {
+        DEEPLOY_KEYS.PIPELINE_PARAMS: {"deeploy_cockroachdb": persisted_allocation},
+      },
+    }
+    plugin, called = self._make_process_update_plugin(
+      discovered_instances=discovered_instances,
+      nodes=nodes,
+      deeploy_specs=deeploy_specs,
+    )
+
+    response = plugin._process_pipeline_request(request, is_create=False, async_mode=True)
+
+    self.assertEqual(response[DEEPLOY_KEYS.STATUS], DEEPLOY_STATUS.SUCCESS)
+    self.assertEqual(
+      response[DEEPLOY_KEYS.STATUS_DETAILS]["cockroachdb_certificate_regeneration"],
+      "already_applied",
+    )
+    self.assertEqual(called["delete"], 0)
+    self.assertEqual(called["deploy"], 0)
+    self.assertEqual(called["queued"], 0)
+
+    changed_request = copy.deepcopy(request)
+    changed_request[DEEPLOY_KEYS.PLUGINS][0]["ENV"]["CRDB_USER"] = "different_user"
+    changed_response = plugin._process_pipeline_request(
+      changed_request,
+      is_create=False,
+      async_mode=True,
+    )
+
+    self.assertIn("different update intent", changed_response[DEEPLOY_KEYS.ERROR])
+    self.assertEqual(called["delete"], 0)
+    self.assertEqual(called["deploy"], 0)
+
+  def test_process_normal_cockroachdb_edit_inherits_running_certificates(self):
+    fixture_plugin = make_deeploy_plugin()
+    nodes, discovered_instances, request_plugin = self._make_four_replica_cockroach_update_fixture(fixture_plugin)
+    cert_bundle = fixture_plugin._generate_cockroachdb_cert_bundle(nodes, "crdb-client.test")
+    for index, discovered in enumerate(discovered_instances):
+      node = discovered[DEEPLOY_PLUGIN_DATA.NODE]
+      runtime_config = discovered[DEEPLOY_PLUGIN_DATA.PLUGIN_INSTANCE]["instance_conf"]
+      if index % 2 == 0:
+        runtime_config["ENV"].update(cert_bundle[node])
+      else:
+        runtime_config["PER_NODE_CONFIG"] = {
+          "byNode": {node: {"ENV": copy.deepcopy(cert_bundle[node])}},
+        }
+    allocation = {
+      "version": 1,
+      "service": "cockroachdb",
+      "status": "allocated",
+      "nodeOrder": nodes,
+      "clientTunnel": {"url": "crdb-client.test:26257"},
+      "internalTunnels": [],
+      "certificateHostname": "crdb-client.test",
+    }
+    plugin, called = self._make_process_update_plugin(
+      discovered_instances=discovered_instances,
+      nodes=nodes,
+      deeploy_specs={
+        DEEPLOY_KEYS.JOB_ID: 11,
+        DEEPLOY_KEYS.JOB_APP_TYPE: JOB_APP_TYPES.SERVICE,
+        DEEPLOY_KEYS.CURRENT_TARGET_NODES: nodes,
+        DEEPLOY_KEYS.JOB_CONFIG: {
+          DEEPLOY_KEYS.PIPELINE_PARAMS: {"deeploy_cockroachdb": copy.deepcopy(allocation)},
+        },
+      },
+    )
+
+    response = plugin._process_pipeline_request(
+      {
+        DEEPLOY_KEYS.APP_ID: "cockroachdb_422ce92",
+        DEEPLOY_KEYS.APP_ALIAS: "cockroachdb",
+        DEEPLOY_KEYS.JOB_ID: 11,
+        DEEPLOY_KEYS.JOB_APP_TYPE: JOB_APP_TYPES.SERVICE,
+        DEEPLOY_KEYS.PIPELINE_INPUT_TYPE: "void",
+        DEEPLOY_KEYS.CHAINSTORE_RESPONSE: False,
+        DEEPLOY_KEYS.TARGET_NODES: nodes,
+        DEEPLOY_KEYS.TARGET_NODES_COUNT: len(nodes),
+        DEEPLOY_KEYS.PIPELINE_PARAMS: {"deeploy_cockroachdb": allocation},
+        DEEPLOY_KEYS.PLUGINS: [request_plugin],
+      },
+      is_create=False,
+      async_mode=True,
+    )
+
+    self.assertEqual(response[DEEPLOY_KEYS.STATUS], DEEPLOY_STATUS.COMMAND_DELIVERED)
+    prepared = called["deploy_kwargs"]["prepared_create_deploy_plan"]
+    for index, node in enumerate(nodes):
+      emitted = prepared["node_plugins_by_addr"][node][0][plugin.ct.CONFIG_PLUGIN.K_INSTANCES][0]
+      overlay = plugin._overlay_for_node(emitted["PER_NODE_CONFIG"], node, index)
+      self.assertEqual(overlay["ENV"]["CRDB_NODE_KEY"], cert_bundle[node]["CRDB_NODE_KEY"])
+    self.assertEqual(called["delete"], 1)
+    self.assertEqual(called["deploy"], 1)
+
+  def test_process_offline_cockroachdb_edit_inherits_persisted_per_node_certificates(self):
+    fixture_plugin = make_deeploy_plugin()
+    nodes, discovered_instances, request_plugin = self._make_four_replica_cockroach_update_fixture(fixture_plugin)
+    cert_bundle = fixture_plugin._generate_cockroachdb_cert_bundle(nodes, "crdb-client.test")
+    persisted_instance = discovered_instances[0]
+    persisted_instance[DEEPLOY_PLUGIN_DATA.NODE] = nodes[0]
+    persisted_instance[DEEPLOY_PLUGIN_DATA.PLUGIN_INSTANCE]["instance_conf"]["PER_NODE_CONFIG"] = {
+      "byNode": {
+        node: {"ENV": copy.deepcopy(cert_bundle[node])}
+        for node in nodes
+      },
+    }
+    allocation = {
+      "version": 1,
+      "service": "cockroachdb",
+      "status": "allocated",
+      "nodeOrder": nodes,
+      "clientTunnel": {"url": "crdb-client.test:26257"},
+      "internalTunnels": [],
+      "certificateHostname": "crdb-client.test",
+    }
+    deeploy_specs = {
+      DEEPLOY_KEYS.JOB_ID: 11,
+      DEEPLOY_KEYS.JOB_APP_TYPE: JOB_APP_TYPES.SERVICE,
+      DEEPLOY_KEYS.CURRENT_TARGET_NODES: nodes,
+      DEEPLOY_KEYS.JOB_CONFIG: {
+        DEEPLOY_KEYS.PIPELINE_PARAMS: {"deeploy_cockroachdb": copy.deepcopy(allocation)},
+      },
+    }
+    plugin, called = self._make_process_update_plugin(
+      discovered_instances=[persisted_instance],
+      nodes=nodes,
+      deeploy_specs=deeploy_specs,
+    )
+    plugin._gather_running_pipeline_context = (
+      lambda **kwargs: (_ for _ in ()).throw(ValueError(f"{DEEPLOY_ERRORS.NODES3}: offline"))
+    )
+    plugin._gather_persisted_pipeline_update_context = lambda **kwargs: {
+      "discovered_instances": [persisted_instance],
+      "nodes": nodes,
+      "deeploy_specs": deeploy_specs,
+    }
+
+    response = plugin._process_pipeline_request(
+      {
+        DEEPLOY_KEYS.APP_ID: "cockroachdb_422ce92",
+        DEEPLOY_KEYS.APP_ALIAS: "cockroachdb",
+        DEEPLOY_KEYS.JOB_ID: 11,
+        DEEPLOY_KEYS.JOB_APP_TYPE: JOB_APP_TYPES.SERVICE,
+        DEEPLOY_KEYS.PIPELINE_INPUT_TYPE: "void",
+        DEEPLOY_KEYS.CHAINSTORE_RESPONSE: False,
+        DEEPLOY_KEYS.TARGET_NODES: nodes,
+        DEEPLOY_KEYS.TARGET_NODES_COUNT: len(nodes),
+        DEEPLOY_KEYS.PIPELINE_PARAMS: {"deeploy_cockroachdb": allocation},
+        DEEPLOY_KEYS.PLUGINS: [request_plugin],
+      },
+      is_create=False,
+      async_mode=True,
+    )
+
+    self.assertEqual(response[DEEPLOY_KEYS.STATUS], DEEPLOY_STATUS.COMMAND_DELIVERED)
+    prepared = called["deploy_kwargs"]["prepared_create_deploy_plan"]
+    for index, node in enumerate(nodes):
+      emitted = prepared["node_plugins_by_addr"][node][0][plugin.ct.CONFIG_PLUGIN.K_INSTANCES][0]
+      overlay = plugin._overlay_for_node(emitted["PER_NODE_CONFIG"], node, index)
+      self.assertEqual(overlay["ENV"]["CRDB_NODE_KEY"], cert_bundle[node]["CRDB_NODE_KEY"])
+    self.assertEqual(called["delete"], 0)
+    self.assertEqual(called["deploy"], 1)
+
+  def test_cockroachdb_regeneration_rejects_live_duplicate_claim(self):
+    plugin = DeeployManagerApiPlugin.__new__(DeeployManagerApiPlugin)
+    regeneration_id = "11111111-1111-4111-8111-111111111111"
+    claim = plugin._claim_cockroachdb_regeneration(
+      "0xOwner", "cockroachdb_422ce92", regeneration_id, "intent-a"
+    )
+
+    with self.assertRaisesRegex(ValueError, "already in progress"):
+      plugin._claim_cockroachdb_regeneration(
+        "0xOwner", "cockroachdb_422ce92", regeneration_id, "intent-a"
+      )
+    with self.assertRaisesRegex(ValueError, "Another CockroachDB certificate regeneration"):
+      plugin._claim_cockroachdb_regeneration(
+        "0xOwner", "cockroachdb_422ce92", regeneration_id, "intent-b"
+      )
+
+    plugin._release_cockroachdb_regeneration(claim)
+    self.assertEqual(
+      plugin._claim_cockroachdb_regeneration(
+        "0xOwner", "cockroachdb_422ce92", regeneration_id, "intent-a"
+      ),
+      claim,
+    )
+
+  def test_cockroachdb_regeneration_reports_persistence_failure_after_three_attempts(self):
+    plugin, called = self._make_process_update_plugin(discovered_instances=[])
+    plugin.persist_job_pipeline_metadata = (
+      lambda **kwargs: called.__setitem__("persisted", called["persisted"] + 1) or False
+    )
+    operation = (
+      "0xOwner",
+      "cockroachdb_422ce92",
+      "11111111-1111-4111-8111-111111111111",
+      "intent-a",
+    )
+    claim_key = plugin._claim_cockroachdb_regeneration(*operation)
+
+    result = plugin.finalize_pending_request_pipeline(
+      pending={
+        "confirm": {"nodes_changed": False},
+        "persistence": {
+          "pipeline": {"NAME": "cockroachdb_422ce92"},
+          "job_id": 11,
+          "previous_cid": "old-cid",
+          "delete_previous": True,
+        },
+        "cockroachdb_regeneration_claim_key": claim_key,
+        "cockroachdb_regeneration_operation": operation,
+        "base_result": {},
+      },
+      dct_status={"response-1": {"node": "node-1"}},
+      str_status=DEEPLOY_STATUS.SUCCESS,
+    )
+
+    self.assertEqual(result[DEEPLOY_KEYS.STATUS], DEEPLOY_STATUS.FAIL)
+    self.assertIn("metadata persistence failed", result[DEEPLOY_KEYS.ERROR])
+    self.assertEqual(called["persisted"], 3)
+    self.assertEqual(called["queued"], 1)
+    self.assertEqual(
+      plugin._cockroachdb_pending_regenerations,
+      {("0xOwner", "cockroachdb_422ce92"): (operation[2], operation[3])},
+    )
+
+  def test_process_cockroachdb_regeneration_replay_uses_recent_confirmed_success(self):
+    fixture_plugin = make_deeploy_plugin()
+    nodes, discovered_instances, request_plugin = self._make_four_replica_cockroach_update_fixture(fixture_plugin)
+    regeneration_id = "11111111-1111-4111-8111-111111111111"
+    allocation = {
+      "version": 1,
+      "service": "cockroachdb",
+      "status": "allocated",
+      "nodeOrder": nodes,
+      "clientTunnel": {"url": "crdb-client.test:26257"},
+      "internalTunnels": [],
+    }
+    request = {
+      DEEPLOY_KEYS.APP_ID: "cockroachdb_422ce92",
+      DEEPLOY_KEYS.APP_ALIAS: "cockroachdb",
+      DEEPLOY_KEYS.JOB_ID: 11,
+      DEEPLOY_KEYS.JOB_APP_TYPE: JOB_APP_TYPES.SERVICE,
+      DEEPLOY_KEYS.PIPELINE_INPUT_TYPE: "void",
+      DEEPLOY_KEYS.CHAINSTORE_RESPONSE: True,
+      DEEPLOY_KEYS.TARGET_NODES: nodes,
+      DEEPLOY_KEYS.TARGET_NODES_COUNT: len(nodes),
+      DEEPLOY_KEYS.PIPELINE_PARAMS: {"deeploy_cockroachdb": allocation},
+      DEEPLOY_KEYS.PLUGINS: [request_plugin],
+      "cockroachdb_certificate_regeneration_id": regeneration_id,
+    }
+    intent_hash = fixture_plugin._cockroachdb_regeneration_intent_hash(make_inputs(**request))
+    stale_specs = {
+      DEEPLOY_KEYS.JOB_ID: 11,
+      DEEPLOY_KEYS.JOB_APP_TYPE: JOB_APP_TYPES.SERVICE,
+      DEEPLOY_KEYS.CURRENT_TARGET_NODES: nodes,
+      DEEPLOY_KEYS.JOB_CONFIG: {
+        DEEPLOY_KEYS.PIPELINE_PARAMS: {"deeploy_cockroachdb": copy.deepcopy(allocation)},
+      },
+    }
+    plugin, called = self._make_process_update_plugin(
+      discovered_instances=discovered_instances,
+      nodes=nodes,
+      deeploy_specs=stale_specs,
+    )
+    applied_specs = copy.deepcopy(stale_specs)
+    applied_specs[DEEPLOY_KEYS.JOB_CONFIG][DEEPLOY_KEYS.PIPELINE_PARAMS][
+      "deeploy_cockroachdb"
+    ].update({
+      "certificateGenerationId": regeneration_id,
+      "certificateRegenerationIntentSha256": intent_hash,
+    })
+    durable_pipeline = {}
+
+    def persist_regeneration(**kwargs):
+      called["persisted"] += 1
+      durable_pipeline.update(copy.deepcopy(kwargs["pipeline"]))
+      return True
+
+    plugin.persist_job_pipeline_metadata = persist_regeneration
+    claim_key = plugin._claim_cockroachdb_regeneration(
+      "0xOwner", "cockroachdb_422ce92", regeneration_id, intent_hash
+    )
+    plugin.finalize_pending_request_pipeline(
+      pending={
+        "confirm": {"nodes_changed": False},
+        "persistence": {
+          "pipeline": {
+            "OWNER": "0xOwner",
+            "NAME": "cockroachdb_422ce92",
+            "DEEPLOY_SPECS": applied_specs,
+          },
+          "job_id": 11,
+          "previous_cid": "old-cid",
+          "delete_previous": True,
+        },
+        "cockroachdb_regeneration_claim_key": claim_key,
+        "cockroachdb_regeneration_operation": (
+          "0xOwner",
+          "cockroachdb_422ce92",
+          regeneration_id,
+          intent_hash,
+        ),
+        "base_result": {},
+      },
+      dct_status={f"response-{index}": {"node": node} for index, node in enumerate(nodes)},
+      str_status=DEEPLOY_STATUS.SUCCESS,
+    )
+    self.assertEqual(called["persisted"], 1)
+    called["queued"] = 0
+    plugin._cockroachdb_applied_regenerations = {}
+    plugin.get_job_pipeline_from_cstore = lambda job_id, **kwargs: copy.deepcopy(durable_pipeline)
+
+    response = plugin._process_pipeline_request(request, is_create=False, async_mode=True)
+
+    self.assertEqual(response[DEEPLOY_KEYS.STATUS], DEEPLOY_STATUS.SUCCESS)
+    self.assertEqual(
+      response[DEEPLOY_KEYS.STATUS_DETAILS]["cockroachdb_certificate_regeneration"],
+      "already_applied",
+    )
+    self.assertEqual(called["delete"], 0)
+    self.assertEqual(called["deploy"], 0)
+
+  def test_process_cockroachdb_regeneration_requires_response_keys_for_all_nodes(self):
+    fixture_plugin = make_deeploy_plugin()
+    nodes, discovered_instances, request_plugin = self._make_four_replica_cockroach_update_fixture(fixture_plugin)
+    allocation = {
+      "version": 1,
+      "service": "cockroachdb",
+      "status": "allocated",
+      "nodeOrder": nodes,
+      "clientTunnel": {"url": "crdb-client.test:26257"},
+      "internalTunnels": [],
+    }
+    persisted_specs = {
+      DEEPLOY_KEYS.JOB_ID: 11,
+      DEEPLOY_KEYS.JOB_APP_TYPE: JOB_APP_TYPES.SERVICE,
+      DEEPLOY_KEYS.CURRENT_TARGET_NODES: nodes,
+      DEEPLOY_KEYS.JOB_CONFIG: {
+        DEEPLOY_KEYS.PIPELINE_PARAMS: {"deeploy_cockroachdb": copy.deepcopy(allocation)},
+      },
+    }
+    request = {
+      DEEPLOY_KEYS.APP_ID: "cockroachdb_422ce92",
+      DEEPLOY_KEYS.APP_ALIAS: "cockroachdb",
+      DEEPLOY_KEYS.JOB_ID: 11,
+      DEEPLOY_KEYS.JOB_APP_TYPE: JOB_APP_TYPES.SERVICE,
+      DEEPLOY_KEYS.PIPELINE_INPUT_TYPE: "void",
+      DEEPLOY_KEYS.CHAINSTORE_RESPONSE: True,
+      DEEPLOY_KEYS.TARGET_NODES: nodes,
+      DEEPLOY_KEYS.TARGET_NODES_COUNT: len(nodes),
+      DEEPLOY_KEYS.PIPELINE_PARAMS: {"deeploy_cockroachdb": allocation},
+      DEEPLOY_KEYS.PLUGINS: [request_plugin],
+      "cockroachdb_certificate_regeneration_id": "11111111-1111-4111-8111-111111111111",
+    }
+    intent_hash = fixture_plugin._cockroachdb_regeneration_intent_hash(make_inputs(**request))
+    live_candidate_specs = copy.deepcopy(persisted_specs)
+    live_candidate_specs[DEEPLOY_KEYS.JOB_CONFIG][DEEPLOY_KEYS.PIPELINE_PARAMS][
+      "deeploy_cockroachdb"
+    ].update({
+      "certificateGenerationId": request["cockroachdb_certificate_regeneration_id"],
+      "certificateRegenerationIntentSha256": intent_hash,
+    })
+    plugin, called = self._make_process_update_plugin(
+      discovered_instances=discovered_instances,
+      nodes=nodes,
+      deeploy_specs=live_candidate_specs,
+    )
+    plugin.get_job_pipeline_from_cstore = lambda job_id, **kwargs: {
+      "OWNER": "0xOwner",
+      "NAME": "cockroachdb_422ce92",
+      "DEEPLOY_SPECS": copy.deepcopy(persisted_specs),
+    }
+    plugin._prepare_create_pipeline_deploy_plan = lambda **kwargs: {
+      "enable_chainstore_response": True,
+      "response_keys": {node: [f"response-{index}"] for index, node in enumerate(nodes[:-1])},
+      "node_plugins_by_addr": {},
+    }
+
+    response = plugin._process_pipeline_request(request, is_create=False, async_mode=True)
+
+    self.assertIn("response keys for every target node", response[DEEPLOY_KEYS.ERROR])
+    self.assertEqual(called["delete"], 0)
+    self.assertEqual(called["deploy"], 0)
 
   def test_process_legacy_service_update_preserves_four_replica_identity_and_storage(self):
     fixture_plugin = make_deeploy_plugin()
@@ -1173,6 +1610,9 @@ class DeeployUpdateRequestPreparationTests(unittest.TestCase):
         },
       ],
     )
+    logs = []
+    plugin.cfg_deeploy_verbose = 2
+    plugin.P = lambda message, **kwargs: logs.append(str(message))
 
     response = plugin._process_pipeline_request(
       {
@@ -1200,10 +1640,10 @@ class DeeployUpdateRequestPreparationTests(unittest.TestCase):
         ],
       },
       is_create=False,
-      async_mode=True,
+      async_mode=False,
     )
 
-    self.assertEqual(response[DEEPLOY_KEYS.STATUS], DEEPLOY_STATUS.COMMAND_DELIVERED)
+    self.assertEqual(response[DEEPLOY_KEYS.STATUS], DEEPLOY_STATUS.SUCCESS)
     self.assertEqual(called["deploy"], 1)
     request_payload = response[DEEPLOY_KEYS.REQUEST]
     self.assertEqual(request_payload[DEEPLOY_KEYS.PLUGINS][0]["ENV"]["API_TOKEN"], "raw-token")
@@ -1211,6 +1651,8 @@ class DeeployUpdateRequestPreparationTests(unittest.TestCase):
       request_payload[DEEPLOY_KEYS.PLUGINS][0]["PER_NODE_CONFIG"]["node-1"]["ENV"]["NODE_PASSWORD"],
       "raw-password",
     )
+    self.assertNotIn("raw-token", "\n".join(logs))
+    self.assertNotIn("raw-password", "\n".join(logs))
 
   def test_process_update_rejects_duplicate_plugin_names_before_delete(self):
     plugin, called = self._make_process_update_plugin(


### PR DESCRIPTION
## Problem
CockroachDB clients can encrypt SQL traffic but cannot authenticate the Deeploy client-facing TCP hostname with `sslmode=verify-full`. Normal edits also need certificate reuse, while deliberate fleet regeneration must be replay-safe.

## Changes
- add the allocated client endpoint DNS/IP identity to every generated node certificate
- preserve complete certificate bundles across live and persisted edit paths
- add UUID-bound, durable, all-node-confirmed full-fleet certificate regeneration
- avoid raw secret-bearing verbose result logs and reject malformed tunnel ports
- add focused request regressions and an isolated three-edge-node TLS runtime bed

## Verification
- 229 Deeploy unit tests passed
- `git diff --check`, validator `py_compile`, and Compose config validation passed
- three edge runtimes plus three published CockroachDB instances passed verify-full, wrong-host/wrong-CA/plaintext negatives, 1,000-row persistence, full regeneration, delayed-node convergence, and packet-canary checks
- fresh GPT-5.5 xhigh adversarial review: GO, no findings

## Boundary
The runtime bed calls production secure-config preparation and directly launches CockroachDB on its isolated network. It does not execute wallet payment, the live manager endpoint, or ContainerAppRunner dispatch. No live nodes or Cloudflare resources were changed.

## Dependency
Paired dapp PR: https://github.com/Ratio1/deeploy-dapp/pull/142

Both PRs target `develop`.